### PR TITLE
esm cite.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rehype-citation",
-  "version": "0.2.0-rc.0",
+  "version": "0.2.0-rc.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1660,33 +1660,6 @@
         "citeproc": "^2.4.6"
       }
     },
-    "@citation-js/plugin-doi": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@citation-js/plugin-doi/-/plugin-doi-0.5.4.tgz",
-      "integrity": "sha512-L5K58SWUYT/QFu6yOt7iB9tysSBeorX2hkE3g4rsgvayHKdmVvfmyaRoEVlxgoDRseLaReevJiYn+LOkrte9Hw==",
-      "requires": {
-        "@citation-js/date": "^0.5.0"
-      }
-    },
-    "@citation-js/plugin-ris": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@citation-js/plugin-ris/-/plugin-ris-0.5.5.tgz",
-      "integrity": "sha512-mP2unuquPA156VhUeLCQquMHpxcAd+jNHpRlMFv7Qz5SATM8z/VTRsBPLC6k2om6bkGok1r5fjpmUO168OGLKA==",
-      "requires": {
-        "@citation-js/date": "^0.5.0",
-        "@citation-js/name": "^0.4.2"
-      }
-    },
-    "@citation-js/plugin-wikidata": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@citation-js/plugin-wikidata/-/plugin-wikidata-0.5.4.tgz",
-      "integrity": "sha512-3DV0j3Rk7RjRjxgyat5lFyg+Uat6jniZAJnKPV+ryWW2N5mhdksBLWqRaTCcsN/CFZ0PEnCY1eRajfIjNKuGjg==",
-      "requires": {
-        "@citation-js/date": "^0.5.0",
-        "@citation-js/name": "^0.4.2",
-        "wikidata-sdk": "7"
-      }
-    },
     "@esbuild-plugins/node-globals-polyfill": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.1.1.tgz",
@@ -2982,46 +2955,6 @@
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-2.0.0.tgz",
       "integrity": "sha512-YwaEtEvWLpFa6Wh3uVLrvirA/ahr9fki/NUd/Bd4OR6EdJ8D22hovYQEOUCBfQfcqnC4IAMGMsHXY1eXgL4ZZA==",
       "dev": true
-    },
-    "citation-js": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/citation-js/-/citation-js-0.5.5.tgz",
-      "integrity": "sha512-jWaLw8A5jrOJ2SbJbqFfMwp89w+qojlsKORfjhL4pm2wqoXer7DKu1gWWU5FCgkO4vn9JFYOThGRioHWo/jYiQ==",
-      "requires": {
-        "@citation-js/cli": "0.5.5",
-        "@citation-js/core": "0.5.4",
-        "@citation-js/date": "0.5.1",
-        "@citation-js/name": "0.4.2",
-        "@citation-js/plugin-bibjson": "0.5.4",
-        "@citation-js/plugin-bibtex": "0.5.5",
-        "@citation-js/plugin-csl": "0.5.5",
-        "@citation-js/plugin-doi": "0.5.4",
-        "@citation-js/plugin-ris": "0.5.5",
-        "@citation-js/plugin-wikidata": "0.5.4",
-        "citeproc": "^2.4.59"
-      },
-      "dependencies": {
-        "@citation-js/cli": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/@citation-js/cli/-/cli-0.5.5.tgz",
-          "integrity": "sha512-U+Xuy+Vzwq/H4X3NYvL3Uj2G+08mMTFuumszRX53HyHUzeBhhh+a42Uhw4dMzrh8SWRy6JDcsijEOww5jC6YHg==",
-          "requires": {
-            "@citation-js/core": "^0.5.4",
-            "@citation-js/plugin-bibjson": "^0.5.4",
-            "@citation-js/plugin-bibtex": "^0.5.5",
-            "@citation-js/plugin-csl": "^0.5.5",
-            "@citation-js/plugin-doi": "^0.5.4",
-            "@citation-js/plugin-ris": "^0.5.5",
-            "@citation-js/plugin-wikidata": "^0.5.4",
-            "commander": "^5.1.0"
-          }
-        },
-        "commander": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
-        }
-      }
     },
     "citeproc": {
       "version": "2.4.62",
@@ -7957,19 +7890,6 @@
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true
-    },
-    "wikibase-sdk": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/wikibase-sdk/-/wikibase-sdk-7.14.2.tgz",
-      "integrity": "sha512-s+U23nKhP+ZA9yfxH/fe5mjZRvcb8/YtinMoKUkr/05MNNWbofUPRZAgQa1B3i0xvQ37zbkhaOP5K3HkC1apwQ=="
-    },
-    "wikidata-sdk": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/wikidata-sdk/-/wikidata-sdk-7.14.2.tgz",
-      "integrity": "sha512-+7cVBKAqaJAfnCTfJZ3rs55mn56TykNh7tm1V17jUtp6yMTt6PoS+GDW0sDaL60fIl+qOHnca4oknHMaTmcBVg==",
-      "requires": {
-        "wikibase-sdk": "^7.14.2"
-      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rehype-citation",
-  "version": "0.1.2",
+  "version": "0.2.0-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rehype-citation",
-  "version": "0.2.0-rc.0",
+  "version": "0.2.0-rc.7",
   "description": "rehype plugin to add citation and bibliography from bibtex files",
   "source": "index.js",
   "files": [
@@ -52,7 +52,6 @@
     "@citation-js/plugin-bibjson": "^0.5.4",
     "@citation-js/plugin-bibtex": "^0.5.5",
     "@citation-js/plugin-csl": "^0.5.5",
-    "citation-js": "^0.5.5",
     "citeproc": "^2.4.62",
     "cross-fetch": "^3.1.5",
     "hast-util-from-parse5": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rehype-citation",
-  "version": "0.1.2",
+  "version": "0.2.0-rc.0",
   "description": "rehype plugin to add citation and bibliography from bibtex files",
   "source": "index.js",
   "files": [

--- a/src/cite.js
+++ b/src/cite.js
@@ -1,17 +1,61 @@
 // Copied as is from https://github.com/larsgw/citation.js/blob/main/index.js
 // commented out doi, ris, wikidata as they are not used in the rehype plugin
-const core = require('@citation-js/core')
 
-require('@citation-js/plugin-bibjson')
-require('@citation-js/plugin-bibtex')
-require('@citation-js/plugin-csl')
+import * as core from '@citation-js/core/lib/index.js'
+import { parsers as coreParsers } from '@citation-js/core/lib/plugin-common/input/index.js'
+import coreOutput from '@citation-js/core/lib/plugin-common/output/index.js'
+
+import '@citation-js/plugin-bibjson/lib/index.js'
+import '@citation-js/plugin-bibtex/lib/index.js'
+import '@citation-js/plugin-csl/lib/index.js'
+import { fetchEngine } from '@citation-js/plugin-csl/lib/engines.js'
+import { parsers as bibjsonParsers } from '@citation-js/plugin-bibjson/lib/index.js'
+import { formats } from '@citation-js/plugin-bibtex/lib/input/index.js'
+import * as entries from '@citation-js/plugin-bibtex/lib/input/entries.js'
+import * as bibtxt from '@citation-js/plugin-bibtex/lib/input/bibtxt.js'
+import bibtexOutput from '@citation-js/plugin-bibtex/lib/output/index.js'
+import * as bibtexOutputEntries from '@citation-js/plugin-bibtex/lib/output/entries.js'
+import { Converters } from '@citation-js/plugin-bibtex/lib/mapping/shared.js'
+import { format as bibtxtFormat } from '@citation-js/plugin-bibtex/lib/output/bibtxt.js'
+
 // require('@citation-js/plugin-doi')
 // require('@citation-js/plugin-ris')
 // require('@citation-js/plugin-wikidata')
 
-const citeproc = require('citeproc')
-const name = require('@citation-js/name')
-const date = require('@citation-js/date')
+import citeproc from 'citeproc'
+import * as name from '@citation-js/name'
+import * as date from '@citation-js/date'
+
+// import bibtexTypes from '@citation-js/plugin-bibtex/lib/mapping/bibtexTypes.json'
+const bibtexTypes = {
+  source: {
+    article: 'article-journal',
+    book: 'book',
+    booklet: 'book',
+    conference: 'paper-conference',
+    inbook: 'chapter',
+    incollection: 'chapter',
+    inproceedings: 'paper-conference',
+    mastersthesis: 'thesis',
+    phdthesis: 'thesis',
+    proceedings: 'book',
+    techreport: 'report',
+    unpublished: 'manuscript',
+  },
+  target: {
+    article: 'article',
+    'article-journal': 'article',
+    'article-magazine': 'article',
+    'article-newspaper': 'article',
+    book: 'book',
+    chapter: 'inbook',
+    manuscript: 'unpublished',
+    'paper-conference': 'inproceedings',
+    report: 'techreport',
+    review: 'article',
+    'review-book': 'article',
+  },
+}
 
 function clone(obj) {
   const copy = {}
@@ -80,7 +124,7 @@ Cite.version = {
 const CSL = core.plugins.config.get('@csl')
 
 Cite.CSL = {
-  engine: require('@citation-js/plugin-csl/lib/engines').fetchEngine,
+  engine: fetchEngine,
   item(data) {
     return (id) => data.find((entry) => entry.id === id)
   },
@@ -123,7 +167,7 @@ Cite.parse = Object.assign(
     date: date.parse,
     csl: core.plugins.input.util.clean,
 
-    bibjson: require('@citation-js/plugin-bibjson').parsers.json.record,
+    bibjson: bibjsonParsers.json.record,
     bibtex: ((parsers, entries, types) => ({
       json(entries) {
         return entries.parse([].concat(entries))
@@ -144,15 +188,11 @@ Cite.parse = Object.assign(
       type(type) {
         return types[type] || 'book'
       },
-    }))(
-      require('@citation-js/plugin-bibtex/lib/input').formats,
-      require('@citation-js/plugin-bibtex/lib/input/entries'),
-      require('@citation-js/plugin-bibtex/lib/mapping/bibtexTypes.json').target
-    ),
+    }))(formats, entries, bibtexTypes.target),
     bibtxt: ((bibtxt) => ({
       text: bibtxt.parse,
       textEntry: bibtxt.textEntry,
-    }))(require('@citation-js/plugin-bibtex/lib/input/bibtxt')),
+    }))(bibtxt),
     // doi: ((doi) => ({
     //   api: doi.parsers.api.parse,
     //   id: doi.parsers.id.parse,
@@ -160,7 +200,7 @@ Cite.parse = Object.assign(
     //     api: doi.parsers.api.parseAsync,
     //   },
     // }))(require('@citation-js/plugin-doi')),
-    json: require('@citation-js/core/lib/plugin-common/input').parsers.json.parse,
+    json: coreParsers.json.parse,
     // wikidata: ((wikidata) => ({
     //   json: wikidata.parsers.entity.parse,
     //   list: wikidata.parsers.id.parse,
@@ -197,17 +237,12 @@ Cite.get = Object.assign(
       type(type) {
         return types[type] || 'misc'
       },
-    }))(
-      require('@citation-js/plugin-bibtex/lib/output').default,
-      require('@citation-js/plugin-bibtex/lib/output/entries'),
-      require('@citation-js/plugin-bibtex/lib/mapping/shared').Converters,
-      require('@citation-js/plugin-bibtex/lib/mapping/bibtexTypes.json').target
-    ),
-    bibtxt: require('@citation-js/plugin-bibtex/lib/output/bibtxt').format,
-    json: require('@citation-js/core/lib/plugin-common/output').default.data,
-    label: require('@citation-js/core/lib/plugin-common/output').default.label,
+    }))(bibtexOutput, bibtexOutputEntries, Converters, bibtexTypes.target),
+    bibtxt: bibtxtFormat,
+    json: coreOutput.data,
+    label: coreOutput.label,
   },
   Cite.plugins.output
 )
 
-module.exports = Cite
+export default Cite

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import rehypeCitationGenerator from './generator.js'
 // @ts-ignore
-import Cite from './cite.cjs'
+import Cite from './cite.js'
 import mla from '../csl/mla.js'
 import chicago from '../csl/chicago.js'
 

--- a/src/parse-citation.js
+++ b/src/parse-citation.js
@@ -138,7 +138,7 @@ export const parseCitation = (citeString) => {
 
       entries.push({
         // Get the first capture group which returns the citekey without @
-        id: [...citeItem.matchAll(citeKeyRe)][0][1],
+        id: citeItem.match(citeKeyRe)[1],
         locator,
         label,
         prefix,
@@ -151,7 +151,7 @@ export const parseCitation = (citeString) => {
     // See https://citeproc-js.readthedocs.io/en/latest/running.html#special-citation-forms
     properties = { noteIndex: 0, mode: 'composite' }
     entries = [citeString].map((str) => ({
-      id: [...str.matchAll(citeKeyRe)][0][1],
+      id: str.match(citeKeyRe)[1],
     }))
   }
   return [properties, entries]

--- a/src/regex.js
+++ b/src/regex.js
@@ -15,5 +15,5 @@
  * */
 export const citeExtractorRe =
   /\[([^[\]]*@[^[\]]+)\]|(?!\b)(@[a-zA-Z0-9_][a-zA-Z0-9_:.#$%&\-+?<>~]*)/
-export const citeKeyRe = /@([a-zA-Z0-9_][a-zA-Z0-9_:.#$%&\-+?<>~]*)/g
+export const citeKeyRe = /@([a-zA-Z0-9_][a-zA-Z0-9_:.#$%&\-+?<>~]*)/
 export const citeBracketRe = /\[.*\]/


### PR DESCRIPTION
- Use ESM version of cite.js for a smaller bundle size
- Fix regex to work on browser and node in build version