### PR TITLE
Add class and id to citations

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ Type: `string[]`.
 
 Citation IDs (@item1) to include in the bibliography even if they are not cited in the document.
 
+#### options.inlineClass
+
+Type: `string[]`.
+
+Array of classes for inline citations.
+
 ### Limitations
 
 1. `link-citations` is not implemented.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ Type: `string[]`.
 
 Array of classes for inline citations.
 
+#### options.inlineBibClass
+
+Type: `string[]`.
+
+Array of classes for inline bibliography. Leave empty to disable inline bibliography.
+
 ### Limitations
 
 1. `link-citations` is not implemented.

--- a/src/generator.js
+++ b/src/generator.js
@@ -85,10 +85,19 @@ const genBiblioNode = (citeproc) => {
   const biblioNode = htmlToHast(bibliography)
 
   // Add citekey id to each bibliography entry.
-  for (let i = 1; i < biblioNode.children.length - 1; i++) {
-    biblioNode.children[i].properties.id = 'bib-' + params.entry_ids[i - 1][0].toLowerCase()
-  }
-  return biblioNode
+  const biblioEntries = {}
+  biblioNode.children
+    .filter((node) => node.properties?.className?.includes('csl-entry'))
+    .forEach((node, i) => {
+      const citekey = params.entry_ids[i][0].toLowerCase()
+
+      node.properties = node.properties || {}
+      node.properties.id = 'bib-' + citekey
+
+      biblioEntries[citekey] = { ...node }
+      biblioEntries[citekey].properties = { id: 'inlinebib-' + citekey }
+    })
+  return { biblioNode, biblioEntries }
 }
 
 /**

--- a/src/generator.js
+++ b/src/generator.js
@@ -63,12 +63,13 @@ const genCitation = (
     []
   )
   // c = [ { bibchange: true, citation_errors: [] }, [ [ 0, '(1)', 'CITATION-1' ] ]]
-  const result = c[1].filter((x) => x[2] === citationId)
+  const idx = c[1].findIndex((x) => x[2] === citationId)
+  // const result = c[1].filter((x) => x[2] === citationId
   // Coerce to html to parse HTML code e.g. &#38; and return text node
   return htmlToHast(
-    `<span class="${(options.inlineClass ?? []).join(' ')}" id=${citationId.toLowerCase()}>${
-      result[0][1]
-    }</span>`
+    `<span class="${(options.inlineClass ?? []).join(' ')}" id=${
+      'citation-' + entries[idx].id.toLowerCase() + '-' + citationId.split('-')[1]
+    }>${c[1][idx][1]}</span>`
   )
 }
 
@@ -147,7 +148,6 @@ const rehypeCitationGenerator = (Cite) => {
         for (const citeItem of entries) {
           if (!citationIds.includes(citeItem.id)) return
         }
-
         const citedTextNode = genCitation(
           citeproc,
           entries,

--- a/src/generator.js
+++ b/src/generator.js
@@ -79,10 +79,15 @@ const genCitation = (
  * @param {*} citeproc
  */
 const genBiblioNode = (citeproc) => {
-  const [, bibBody] = citeproc.makeBibliography()
+  const [params, bibBody] = citeproc.makeBibliography()
   const bibliography =
     '<div id="refs" class="references csl-bib-body">\n' + bibBody.join('') + '</div>'
   const biblioNode = htmlToHast(bibliography)
+
+  // Add citekey id to each bibliography entry.
+  for (let i = 1; i < biblioNode.children.length - 1; i++) {
+    biblioNode.children[i].properties.id = 'bib-' + params.entry_ids[i - 1][0].toLowerCase()
+  }
   return biblioNode
 }
 

--- a/src/generator.js
+++ b/src/generator.js
@@ -200,7 +200,10 @@ const rehypeCitationGenerator = (Cite) => {
         citeproc.updateItems(options.noCite.map((x) => x.replace('@', '')))
       }
 
-      if (citeproc.registry.mylist.length >= 1) {
+      if (
+        citeproc.registry.mylist.length >= 1 &&
+        (!options.suppressBibliography || options.inlineBibClass?.length > 0)
+      ) {
         const { biblioNode, biblioEntries } = genBiblioNode(citeproc)
         let bilioInserted = false
 

--- a/src/generator.js
+++ b/src/generator.js
@@ -19,6 +19,8 @@
  *   If the file contains `[^Ref]`, the biliography will be inserted there instead.
  * @property {string[]} [noCite]
  *   Citation IDs (@item1) to include in the bibliography even if they are not cited in the document
+ * @property {string[]} [inlineClass]
+ *   Class(es) to add to the inline citation.
  */
 
 import { visit } from 'unist-util-visit'
@@ -39,10 +41,18 @@ const permittedTags = ['div', 'p', 'span', 'li']
  * @param {CiteItem[]} entries
  * @param {string} citationId
  * @param {any[]} citationPre
+ * @param {Options} options
  * @param {*} [properties={ noteIndex: 0 }]
  * @return {*}
  */
-const genCitation = (citeproc, entries, citationId, citationPre, properties = { noteIndex: 0 }) => {
+const genCitation = (
+  citeproc,
+  entries,
+  citationId,
+  citationPre,
+  options,
+  properties = { noteIndex: 0 }
+) => {
   const c = citeproc.processCitationCluster(
     {
       citationID: citationId,
@@ -55,9 +65,11 @@ const genCitation = (citeproc, entries, citationId, citationPre, properties = { 
   // c = [ { bibchange: true, citation_errors: [] }, [ [ 0, '(1)', 'CITATION-1' ] ]]
   const result = c[1].filter((x) => x[2] === citationId)
   // Coerce to html to parse HTML code e.g. &#38; and return text node
-  const citeNode = htmlToHast(`<div>${result[0][1]}</div>`)
-  const textNode = citeNode.children[0]
-  return textNode
+  return htmlToHast(
+    `<span class="${(options.inlineClass ?? []).join(' ')}" id=${citationId.toLowerCase()}>${
+      result[0][1]
+    }</span>`
+  )
 }
 
 /**
@@ -141,6 +153,7 @@ const rehypeCitationGenerator = (Cite) => {
           entries,
           `CITATION-${citationId}`,
           citationPre,
+          options,
           properties
         )
 

--- a/test/generator.js
+++ b/test/generator.js
@@ -21,7 +21,7 @@ const generatorTest = suite('generator')
 generatorTest('custom cite plugin', async () => {
   const rehypeCitation = rehypeCitationGenerator(Cite)
   const result = await processHtml(rehypeCitation, `<div>[@Nash1950]</div>`)
-  const expected = dedent`<div><span class="" id="citation-nash1950-1">(Nash, 1950)</span></div><div id="refs" class="references csl-bib-body">
+  const expected = dedent`<div><span class="" id="citation--nash1950--1">(Nash, 1950)</span></div><div id="refs" class="references csl-bib-body">
           <div class="csl-entry" id="bib-nash1950">Nash, J. (1950). Equilibrium points in n-person games. <i>Proceedings of the National Academy of Sciences</i>, <i>36</i>(1), 48–49.</div>
         </div>`
   assert.is(result, expected)
@@ -35,7 +35,7 @@ generatorTest('custom locale', async () => {
     suppressBibliography: true,
     lang: 'zh-CN',
   })
-  const expected = dedent`<div><span class="" id="citation-nash1950-1">(Nash, 1950, 章 1)</span></div>`
+  const expected = dedent`<div><span class="" id="citation--nash1950--1">(Nash, 1950, 章 1)</span></div>`
   assert.is(result, expected)
 })
 
@@ -47,7 +47,7 @@ generatorTest('properly account for previous citation', async () => {
     suppressBibliography: true,
     csl: 'vancouver',
   })
-  const expected = dedent`<div><span class="" id="citation-nash1951-1">(1)</span> text <span class="" id="citation-nash1950-2">(2)</span></div>`
+  const expected = dedent`<div><span class="" id="citation--nash1951--1">(1)</span> text <span class="" id="citation--nash1950--2">(2)</span></div>`
   assert.is(result, expected)
 })
 

--- a/test/generator.js
+++ b/test/generator.js
@@ -21,7 +21,7 @@ const generatorTest = suite('generator')
 generatorTest('custom cite plugin', async () => {
   const rehypeCitation = rehypeCitationGenerator(Cite)
   const result = await processHtml(rehypeCitation, `<div>[@Nash1950]</div>`)
-  const expected = dedent`<div>(Nash, 1950)</div><div id="refs" class="references csl-bib-body">
+  const expected = dedent`<div><span class="" id="citation-1">(Nash, 1950)</span></div><div id="refs" class="references csl-bib-body">
           <div class="csl-entry">Nash, J. (1950). Equilibrium points in n-person games. <i>Proceedings of the National Academy of Sciences</i>, <i>36</i>(1), 48–49.</div>
         </div>`
   assert.is(result, expected)
@@ -35,7 +35,7 @@ generatorTest('custom locale', async () => {
     suppressBibliography: true,
     lang: 'zh-CN',
   })
-  const expected = dedent`<div>(Nash, 1950, 章 1)</div>`
+  const expected = dedent`<div><span class="" id="citation-1">(Nash, 1950, 章 1)</span></div>`
   assert.is(result, expected)
 })
 
@@ -47,7 +47,7 @@ generatorTest('properly account for previous citation', async () => {
     suppressBibliography: true,
     csl: 'vancouver',
   })
-  const expected = dedent`<div>(1) text (2)</div>`
+  const expected = dedent`<div><span class="" id="citation-1">(1)</span> text <span class="" id="citation-2">(2)</span></div>`
   assert.is(result, expected)
 })
 

--- a/test/generator.js
+++ b/test/generator.js
@@ -22,7 +22,7 @@ generatorTest('custom cite plugin', async () => {
   const rehypeCitation = rehypeCitationGenerator(Cite)
   const result = await processHtml(rehypeCitation, `<div>[@Nash1950]</div>`)
   const expected = dedent`<div><span class="" id="citation-nash1950-1">(Nash, 1950)</span></div><div id="refs" class="references csl-bib-body">
-          <div class="csl-entry">Nash, J. (1950). Equilibrium points in n-person games. <i>Proceedings of the National Academy of Sciences</i>, <i>36</i>(1), 48–49.</div>
+          <div class="csl-entry" id="bib-nash1950">Nash, J. (1950). Equilibrium points in n-person games. <i>Proceedings of the National Academy of Sciences</i>, <i>36</i>(1), 48–49.</div>
         </div>`
   assert.is(result, expected)
 })

--- a/test/generator.js
+++ b/test/generator.js
@@ -21,7 +21,7 @@ const generatorTest = suite('generator')
 generatorTest('custom cite plugin', async () => {
   const rehypeCitation = rehypeCitationGenerator(Cite)
   const result = await processHtml(rehypeCitation, `<div>[@Nash1950]</div>`)
-  const expected = dedent`<div><span class="" id="citation-1">(Nash, 1950)</span></div><div id="refs" class="references csl-bib-body">
+  const expected = dedent`<div><span class="" id="citation-nash1950-1">(Nash, 1950)</span></div><div id="refs" class="references csl-bib-body">
           <div class="csl-entry">Nash, J. (1950). Equilibrium points in n-person games. <i>Proceedings of the National Academy of Sciences</i>, <i>36</i>(1), 48–49.</div>
         </div>`
   assert.is(result, expected)
@@ -35,7 +35,7 @@ generatorTest('custom locale', async () => {
     suppressBibliography: true,
     lang: 'zh-CN',
   })
-  const expected = dedent`<div><span class="" id="citation-1">(Nash, 1950, 章 1)</span></div>`
+  const expected = dedent`<div><span class="" id="citation-nash1950-1">(Nash, 1950, 章 1)</span></div>`
   assert.is(result, expected)
 })
 
@@ -47,7 +47,7 @@ generatorTest('properly account for previous citation', async () => {
     suppressBibliography: true,
     csl: 'vancouver',
   })
-  const expected = dedent`<div><span class="" id="citation-1">(1)</span> text <span class="" id="citation-2">(2)</span></div>`
+  const expected = dedent`<div><span class="" id="citation-nash1951-1">(1)</span> text <span class="" id="citation-nash1950-2">(2)</span></div>`
   assert.is(result, expected)
 })
 

--- a/test/index.js
+++ b/test/index.js
@@ -19,13 +19,13 @@ const rehypeCitationTest = suite('rehype-citation')
 
 rehypeCitationTest('parse citation correctly', async () => {
   const result = await processHtml(dedent`<div>[@Nash1950]</div>`, { suppressBibliography: true })
-  const expected = dedent`<div>(Nash, 1950)</div>`
+  const expected = dedent`<div><span class="" id="citation-1">(Nash, 1950)</span></div>`
   assert.is(result, expected)
 })
 
 rehypeCitationTest('parse in-text citation correctly', async () => {
   const result = await processHtml('<div>@Nash1950</div>', { suppressBibliography: true })
-  const expected = dedent`<div>Nash (1950)</div>`
+  const expected = dedent`<div><span class="" id="citation-1">Nash (1950)</span></div>`
   assert.is(result, expected)
 })
 
@@ -40,7 +40,7 @@ rehypeCitationTest('properly account for previous citation', async () => {
     suppressBibliography: true,
     csl: 'vancouver',
   })
-  const expected = dedent`<div>(1) text (2)</div>`
+  const expected = dedent`<div><span class="" id="citation-1">(1)</span> text <span class="" id="citation-2">(2)</span></div>`
   assert.is(result, expected)
 })
 
@@ -49,13 +49,13 @@ rehypeCitationTest('parse multiple citations correctly', async () => {
     '<div>First citation @Nash1950 and second citation [@Nash1951]</div>',
     { suppressBibliography: true }
   )
-  const expected = dedent`<div>First citation Nash (1950) and second citation (Nash, 1951)</div>`
+  const expected = dedent`<div>First citation <span class="" id="citation-1">Nash (1950)</span> and second citation <span class="" id="citation-2">(Nash, 1951)</span></div>`
   assert.is(result, expected)
 })
 
 rehypeCitationTest('inserts biliography at the end of the file', async () => {
   const result = await processHtml('<div>[@Nash1950]</div>')
-  const expected = dedent`<div>(Nash, 1950)</div><div id="refs" class="references csl-bib-body">
+  const expected = dedent`<div><span class="" id="citation-1">(Nash, 1950)</span></div><div id="refs" class="references csl-bib-body">
           <div class="csl-entry">Nash, J. (1950). Equilibrium points in n-person games. <i>Proceedings of the National Academy of Sciences</i>, <i>36</i>(1), 48–49.</div>
         </div>`
   assert.is(result, expected)
@@ -65,7 +65,7 @@ rehypeCitationTest('inserts biliography at [^ref] div tag', async () => {
   const result = await processHtml('<div>[^ref]</div><div>[@Nash1950]</div>')
   const expected = dedent`<div id="refs" class="references csl-bib-body">
           <div class="csl-entry">Nash, J. (1950). Equilibrium points in n-person games. <i>Proceedings of the National Academy of Sciences</i>, <i>36</i>(1), 48–49.</div>
-        </div><div>(Nash, 1950)</div>`
+        </div><div><span class="" id="citation-1">(Nash, 1950)</span></div>`
   assert.is(result, expected)
 })
 
@@ -74,7 +74,7 @@ rehypeCitationTest('supports other specified csl', async () => {
     suppressBibliography: true,
     csl: 'chicago',
   })
-  const expected = dedent`<div>Nash (1950)</div>`
+  const expected = dedent`<div><span class="" id="citation-1">Nash (1950)</span></div>`
   assert.is(result, expected)
 })
 
@@ -82,7 +82,7 @@ rehypeCitationTest('process HTML code', async () => {
   const result = await processHtml('<div>@verma-rubin</div>', {
     suppressBibliography: true,
   })
-  const expected = dedent`<div>Verma &#x26; Rubin (2018)</div>`
+  const expected = dedent`<div><span class="" id="citation-1">Verma &#x26; Rubin (2018)</span></div>`
   assert.is(result, expected)
 })
 
@@ -91,13 +91,13 @@ rehypeCitationTest('supports csl from path', async () => {
     suppressBibliography: true,
     csl: './csl/chicago.csl',
   })
-  const expected = dedent`<div>Nash (1950)</div>`
+  const expected = dedent`<div><span class="" id="citation-1">Nash (1950)</span></div>`
   assert.is(result, expected)
 })
 
 rehypeCitationTest('parse li', async () => {
   const result = await processHtml('<ul><li>@Nash1950</li></ul>', { suppressBibliography: true })
-  const expected = dedent`<ul><li>Nash (1950)</li></ul>`
+  const expected = dedent`<ul><li><span class="" id="citation-1">Nash (1950)</span></li></ul>`
   assert.is(result, expected)
 })
 
@@ -115,13 +115,13 @@ rehypeCitationTest('handle prefix, suffix and locator', async () => {
   const result = await processHtml(dedent`<div>[see @Nash1950, 5-6 suffix]</div>`, {
     suppressBibliography: true,
   })
-  const expected = dedent`<div>(see Nash, 1950, pp. 5–6 suffix)</div>`
+  const expected = dedent`<div><span class="" id="citation-1">(see Nash, 1950, pp. 5–6 suffix)</span></div>`
   assert.is(result, expected)
 })
 
 rehypeCitationTest('suppress author', async () => {
   const result = await processHtml(dedent`<div>[-@Nash1950]</div>`, { suppressBibliography: true })
-  const expected = dedent`<div>(1950)</div>`
+  const expected = dedent`<div><span class="" id="citation-1">(1950)</span></div>`
   assert.is(result, expected)
 })
 
@@ -144,7 +144,7 @@ rehypeCitationTest('works with csl-json', async () => {
     { suppressBibliography: true },
     cslJSON
   )
-  const expected = dedent`<div>(Hall, 1957)</div>`
+  const expected = dedent`<div><span class="" id="citation-1">(Hall, 1957)</span></div>`
   assert.is(result, expected)
 })
 
@@ -154,7 +154,7 @@ rehypeCitationTest('works with url bibliography path', async () => {
     { suppressBibliography: true },
     'https://raw.githubusercontent.com/retorquere/zotero-better-bibtex/v6.0.0/test/fixtures/import/Author%20splitter%20failure.bib'
   )
-  const expected = dedent`<div>(Abu-Zeid et al., 1986)</div>`
+  const expected = dedent`<div><span class="" id="citation-1">(Abu-Zeid et al., 1986)</span></div>`
   assert.is(result, expected)
 })
 
@@ -169,6 +169,24 @@ rehypeCitationTest('throw error if invalid url path', async () => {
   } catch (err) {
     assert.instance(err, Error)
   }
+})
+
+rehypeCitationTest('works with an inline class', async () => {
+  const result = await processHtml(dedent`<div>[@Nash1950]</div>`, {
+    suppressBibliography: true,
+    inlineClass: ['testClass'],
+  })
+  const expected = dedent`<div><span class="testClass" id="citation-1">(Nash, 1950)</span></div>`
+  assert.is(result, expected)
+})
+
+rehypeCitationTest('works with multiple inline classes', async () => {
+  const result = await processHtml(dedent`<div>[@Nash1950]</div>`, {
+    suppressBibliography: true,
+    inlineClass: ['testClass', 'testClass2'],
+  })
+  const expected = dedent`<div><span class="testClass testClass2" id="citation-1">(Nash, 1950)</span></div>`
+  assert.is(result, expected)
 })
 
 rehypeCitationTest.run()

--- a/test/index.js
+++ b/test/index.js
@@ -19,13 +19,13 @@ const rehypeCitationTest = suite('rehype-citation')
 
 rehypeCitationTest('parse citation correctly', async () => {
   const result = await processHtml(dedent`<div>[@Nash1950]</div>`, { suppressBibliography: true })
-  const expected = dedent`<div><span class="" id="citation-nash1950-1">(Nash, 1950)</span></div>`
+  const expected = dedent`<div><span class="" id="citation--nash1950--1">(Nash, 1950)</span></div>`
   assert.is(result, expected)
 })
 
 rehypeCitationTest('parse in-text citation correctly', async () => {
   const result = await processHtml('<div>@Nash1950</div>', { suppressBibliography: true })
-  const expected = dedent`<div><span class="" id="citation-nash1950-1">Nash (1950)</span></div>`
+  const expected = dedent`<div><span class="" id="citation--nash1950--1">Nash (1950)</span></div>`
   assert.is(result, expected)
 })
 
@@ -40,7 +40,7 @@ rehypeCitationTest('properly account for previous citation', async () => {
     suppressBibliography: true,
     csl: 'vancouver',
   })
-  const expected = dedent`<div><span class="" id="citation-nash1951-1">(1)</span> text <span class="" id="citation-nash1950-2">(2)</span></div>`
+  const expected = dedent`<div><span class="" id="citation--nash1951--1">(1)</span> text <span class="" id="citation--nash1950--2">(2)</span></div>`
   assert.is(result, expected)
 })
 
@@ -49,13 +49,13 @@ rehypeCitationTest('parse multiple citations correctly', async () => {
     '<div>First citation @Nash1950 and second citation [@Nash1951]</div>',
     { suppressBibliography: true }
   )
-  const expected = dedent`<div>First citation <span class="" id="citation-nash1950-1">Nash (1950)</span> and second citation <span class="" id="citation-nash1951-2">(Nash, 1951)</span></div>`
+  const expected = dedent`<div>First citation <span class="" id="citation--nash1950--1">Nash (1950)</span> and second citation <span class="" id="citation--nash1951--2">(Nash, 1951)</span></div>`
   assert.is(result, expected)
 })
 
 rehypeCitationTest('inserts biliography at the end of the file', async () => {
   const result = await processHtml('<div>[@Nash1950]</div>')
-  const expected = dedent`<div><span class="" id="citation-nash1950-1">(Nash, 1950)</span></div><div id="refs" class="references csl-bib-body">
+  const expected = dedent`<div><span class="" id="citation--nash1950--1">(Nash, 1950)</span></div><div id="refs" class="references csl-bib-body">
           <div class="csl-entry" id="bib-nash1950">Nash, J. (1950). Equilibrium points in n-person games. <i>Proceedings of the National Academy of Sciences</i>, <i>36</i>(1), 48–49.</div>
         </div>`
   assert.is(result, expected)
@@ -65,7 +65,7 @@ rehypeCitationTest('inserts biliography at [^ref] div tag', async () => {
   const result = await processHtml('<div>[^ref]</div><div>[@Nash1950]</div>')
   const expected = dedent`<div id="refs" class="references csl-bib-body">
           <div class="csl-entry" id="bib-nash1950">Nash, J. (1950). Equilibrium points in n-person games. <i>Proceedings of the National Academy of Sciences</i>, <i>36</i>(1), 48–49.</div>
-        </div><div><span class="" id="citation-nash1950-1">(Nash, 1950)</span></div>`
+        </div><div><span class="" id="citation--nash1950--1">(Nash, 1950)</span></div>`
   assert.is(result, expected)
 })
 
@@ -74,7 +74,7 @@ rehypeCitationTest('supports other specified csl', async () => {
     suppressBibliography: true,
     csl: 'chicago',
   })
-  const expected = dedent`<div><span class="" id="citation-nash1950-1">Nash (1950)</span></div>`
+  const expected = dedent`<div><span class="" id="citation--nash1950--1">Nash (1950)</span></div>`
   assert.is(result, expected)
 })
 
@@ -82,7 +82,7 @@ rehypeCitationTest('process HTML code', async () => {
   const result = await processHtml('<div>@verma-rubin</div>', {
     suppressBibliography: true,
   })
-  const expected = dedent`<div><span class="" id="citation-verma-rubin-1">Verma &#x26; Rubin (2018)</span></div>`
+  const expected = dedent`<div><span class="" id="citation--verma-rubin--1">Verma &#x26; Rubin (2018)</span></div>`
   assert.is(result, expected)
 })
 
@@ -91,13 +91,13 @@ rehypeCitationTest('supports csl from path', async () => {
     suppressBibliography: true,
     csl: './csl/chicago.csl',
   })
-  const expected = dedent`<div><span class="" id="citation-nash1950-1">Nash (1950)</span></div>`
+  const expected = dedent`<div><span class="" id="citation--nash1950--1">Nash (1950)</span></div>`
   assert.is(result, expected)
 })
 
 rehypeCitationTest('parse li', async () => {
   const result = await processHtml('<ul><li>@Nash1950</li></ul>', { suppressBibliography: true })
-  const expected = dedent`<ul><li><span class="" id="citation-nash1950-1">Nash (1950)</span></li></ul>`
+  const expected = dedent`<ul><li><span class="" id="citation--nash1950--1">Nash (1950)</span></li></ul>`
   assert.is(result, expected)
 })
 
@@ -115,13 +115,13 @@ rehypeCitationTest('handle prefix, suffix and locator', async () => {
   const result = await processHtml(dedent`<div>[see @Nash1950, 5-6 suffix]</div>`, {
     suppressBibliography: true,
   })
-  const expected = dedent`<div><span class="" id="citation-nash1950-1">(see Nash, 1950, pp. 5–6 suffix)</span></div>`
+  const expected = dedent`<div><span class="" id="citation--nash1950--1">(see Nash, 1950, pp. 5–6 suffix)</span></div>`
   assert.is(result, expected)
 })
 
 rehypeCitationTest('suppress author', async () => {
   const result = await processHtml(dedent`<div>[-@Nash1950]</div>`, { suppressBibliography: true })
-  const expected = dedent`<div><span class="" id="citation-nash1950-1">(1950)</span></div>`
+  const expected = dedent`<div><span class="" id="citation--nash1950--1">(1950)</span></div>`
   assert.is(result, expected)
 })
 
@@ -144,7 +144,7 @@ rehypeCitationTest('works with csl-json', async () => {
     { suppressBibliography: true },
     cslJSON
   )
-  const expected = dedent`<div><span class="" id="citation-q23571040-1">(Hall, 1957)</span></div>`
+  const expected = dedent`<div><span class="" id="citation--q23571040--1">(Hall, 1957)</span></div>`
   assert.is(result, expected)
 })
 
@@ -154,7 +154,7 @@ rehypeCitationTest('works with url bibliography path', async () => {
     { suppressBibliography: true },
     'https://raw.githubusercontent.com/retorquere/zotero-better-bibtex/v6.0.0/test/fixtures/import/Author%20splitter%20failure.bib'
   )
-  const expected = dedent`<div><span class="" id="citation-abu-zeid_1986-1">(Abu-Zeid et al., 1986)</span></div>`
+  const expected = dedent`<div><span class="" id="citation--abu-zeid_1986--1">(Abu-Zeid et al., 1986)</span></div>`
   assert.is(result, expected)
 })
 
@@ -176,7 +176,7 @@ rehypeCitationTest('works with an inline class', async () => {
     suppressBibliography: true,
     inlineClass: ['testClass'],
   })
-  const expected = dedent`<div><span class="testClass" id="citation-nash1950-1">(Nash, 1950)</span></div>`
+  const expected = dedent`<div><span class="testClass" id="citation--nash1950--1">(Nash, 1950)</span></div>`
   assert.is(result, expected)
 })
 
@@ -185,7 +185,7 @@ rehypeCitationTest('works with multiple inline classes', async () => {
     suppressBibliography: true,
     inlineClass: ['testClass', 'testClass2'],
   })
-  const expected = dedent`<div><span class="testClass testClass2" id="citation-nash1950-1">(Nash, 1950)</span></div>`
+  const expected = dedent`<div><span class="testClass testClass2" id="citation--nash1950--1">(Nash, 1950)</span></div>`
   assert.is(result, expected)
 })
 
@@ -194,7 +194,27 @@ rehypeCitationTest('generates inline bib', async () => {
     suppressBibliography: true,
     inlineBibClass: ['testBibClass', 'testBibClass2'],
   })
-  const expected = dedent`<div><span class="" id="citation-nash1950-1">(Nash, 1950)</span><div id="inlinebib-nash1950" class="testBibClass testBibClass2">Nash, J. (1950). Equilibrium points in n-person games. <i>Proceedings of the National Academy of Sciences</i>, <i>36</i>(1), 48–49.</div></div>`
+  const expected = dedent`<div>
+    <span class="" id="citation--nash1950--1">(Nash, 1950)</span>
+    <div class="testBibClass testBibClass2" id="inlineBib--nash1950--1">
+    <div class="inline-entry" id="inline--nash1950--1">Nash, J. (1950). Equilibrium points in n-person games. <i>Proceedings of the National Academy of Sciences</i>, <i>36</i>(1), 48–49.</div>
+    </div>
+    </div>`.replace(/\n/g, '')
+  assert.is(result, expected)
+})
+
+rehypeCitationTest('generates multiple inline bibs', async () => {
+  const result = await processHtml(dedent`<div>[@Nash1950; @Nash1951]</div>`, {
+    suppressBibliography: true,
+    inlineBibClass: ['testBibClass', 'testBibClass2'],
+  })
+  const expected = dedent`<div>
+    <span class="" id="citation--nash1950--nash1951--1">(Nash, 1950, 1951)</span>
+    <div class="testBibClass testBibClass2" id="inlineBib--nash1950--nash1951--1">
+    <div class="inline-entry" id="inline--nash1950--1">Nash, J. (1950). Equilibrium points in n-person games. <i>Proceedings of the National Academy of Sciences</i>, <i>36</i>(1), 48–49.</div>
+    <div class="inline-entry" id="inline--nash1951--1">Nash, J. (1951). Non-cooperative games. <i>Annals of Mathematics</i>, 286–295.</div>
+    </div>
+    </div>`.replace(/\n/g, '')
   assert.is(result, expected)
 })
 

--- a/test/index.js
+++ b/test/index.js
@@ -189,4 +189,13 @@ rehypeCitationTest('works with multiple inline classes', async () => {
   assert.is(result, expected)
 })
 
+rehypeCitationTest('generates inline bib', async () => {
+  const result = await processHtml(dedent`<div>[@Nash1950]</div>`, {
+    suppressBibliography: true,
+    inlineBibClass: ['testBibClass', 'testBibClass2'],
+  })
+  const expected = dedent`<div><span class="" id="citation-nash1950-1">(Nash, 1950)</span><div id="inlinebib-nash1950" class="testBibClass testBibClass2">Nash, J. (1950). Equilibrium points in n-person games. <i>Proceedings of the National Academy of Sciences</i>, <i>36</i>(1), 48–49.</div></div>`
+  assert.is(result, expected)
+})
+
 rehypeCitationTest.run()

--- a/test/index.js
+++ b/test/index.js
@@ -56,7 +56,7 @@ rehypeCitationTest('parse multiple citations correctly', async () => {
 rehypeCitationTest('inserts biliography at the end of the file', async () => {
   const result = await processHtml('<div>[@Nash1950]</div>')
   const expected = dedent`<div><span class="" id="citation-nash1950-1">(Nash, 1950)</span></div><div id="refs" class="references csl-bib-body">
-          <div class="csl-entry">Nash, J. (1950). Equilibrium points in n-person games. <i>Proceedings of the National Academy of Sciences</i>, <i>36</i>(1), 48–49.</div>
+          <div class="csl-entry" id="bib-nash1950">Nash, J. (1950). Equilibrium points in n-person games. <i>Proceedings of the National Academy of Sciences</i>, <i>36</i>(1), 48–49.</div>
         </div>`
   assert.is(result, expected)
 })
@@ -64,7 +64,7 @@ rehypeCitationTest('inserts biliography at the end of the file', async () => {
 rehypeCitationTest('inserts biliography at [^ref] div tag', async () => {
   const result = await processHtml('<div>[^ref]</div><div>[@Nash1950]</div>')
   const expected = dedent`<div id="refs" class="references csl-bib-body">
-          <div class="csl-entry">Nash, J. (1950). Equilibrium points in n-person games. <i>Proceedings of the National Academy of Sciences</i>, <i>36</i>(1), 48–49.</div>
+          <div class="csl-entry" id="bib-nash1950">Nash, J. (1950). Equilibrium points in n-person games. <i>Proceedings of the National Academy of Sciences</i>, <i>36</i>(1), 48–49.</div>
         </div><div><span class="" id="citation-nash1950-1">(Nash, 1950)</span></div>`
   assert.is(result, expected)
 })
@@ -106,7 +106,7 @@ rehypeCitationTest('no-cite', async () => {
     noCite: ['@Nash1950'],
   })
   const expected = dedent`<div>text</div><div id="refs" class="references csl-bib-body">
-          <div class="csl-entry">Nash, J. (1950). Equilibrium points in n-person games. <i>Proceedings of the National Academy of Sciences</i>, <i>36</i>(1), 48–49.</div>
+          <div class="csl-entry" id="bib-nash1950">Nash, J. (1950). Equilibrium points in n-person games. <i>Proceedings of the National Academy of Sciences</i>, <i>36</i>(1), 48–49.</div>
         </div>`
   assert.is(result, expected)
 })

--- a/test/index.js
+++ b/test/index.js
@@ -19,13 +19,13 @@ const rehypeCitationTest = suite('rehype-citation')
 
 rehypeCitationTest('parse citation correctly', async () => {
   const result = await processHtml(dedent`<div>[@Nash1950]</div>`, { suppressBibliography: true })
-  const expected = dedent`<div><span class="" id="citation-1">(Nash, 1950)</span></div>`
+  const expected = dedent`<div><span class="" id="citation-nash1950-1">(Nash, 1950)</span></div>`
   assert.is(result, expected)
 })
 
 rehypeCitationTest('parse in-text citation correctly', async () => {
   const result = await processHtml('<div>@Nash1950</div>', { suppressBibliography: true })
-  const expected = dedent`<div><span class="" id="citation-1">Nash (1950)</span></div>`
+  const expected = dedent`<div><span class="" id="citation-nash1950-1">Nash (1950)</span></div>`
   assert.is(result, expected)
 })
 
@@ -40,7 +40,7 @@ rehypeCitationTest('properly account for previous citation', async () => {
     suppressBibliography: true,
     csl: 'vancouver',
   })
-  const expected = dedent`<div><span class="" id="citation-1">(1)</span> text <span class="" id="citation-2">(2)</span></div>`
+  const expected = dedent`<div><span class="" id="citation-nash1951-1">(1)</span> text <span class="" id="citation-nash1950-2">(2)</span></div>`
   assert.is(result, expected)
 })
 
@@ -49,13 +49,13 @@ rehypeCitationTest('parse multiple citations correctly', async () => {
     '<div>First citation @Nash1950 and second citation [@Nash1951]</div>',
     { suppressBibliography: true }
   )
-  const expected = dedent`<div>First citation <span class="" id="citation-1">Nash (1950)</span> and second citation <span class="" id="citation-2">(Nash, 1951)</span></div>`
+  const expected = dedent`<div>First citation <span class="" id="citation-nash1950-1">Nash (1950)</span> and second citation <span class="" id="citation-nash1951-2">(Nash, 1951)</span></div>`
   assert.is(result, expected)
 })
 
 rehypeCitationTest('inserts biliography at the end of the file', async () => {
   const result = await processHtml('<div>[@Nash1950]</div>')
-  const expected = dedent`<div><span class="" id="citation-1">(Nash, 1950)</span></div><div id="refs" class="references csl-bib-body">
+  const expected = dedent`<div><span class="" id="citation-nash1950-1">(Nash, 1950)</span></div><div id="refs" class="references csl-bib-body">
           <div class="csl-entry">Nash, J. (1950). Equilibrium points in n-person games. <i>Proceedings of the National Academy of Sciences</i>, <i>36</i>(1), 48–49.</div>
         </div>`
   assert.is(result, expected)
@@ -65,7 +65,7 @@ rehypeCitationTest('inserts biliography at [^ref] div tag', async () => {
   const result = await processHtml('<div>[^ref]</div><div>[@Nash1950]</div>')
   const expected = dedent`<div id="refs" class="references csl-bib-body">
           <div class="csl-entry">Nash, J. (1950). Equilibrium points in n-person games. <i>Proceedings of the National Academy of Sciences</i>, <i>36</i>(1), 48–49.</div>
-        </div><div><span class="" id="citation-1">(Nash, 1950)</span></div>`
+        </div><div><span class="" id="citation-nash1950-1">(Nash, 1950)</span></div>`
   assert.is(result, expected)
 })
 
@@ -74,7 +74,7 @@ rehypeCitationTest('supports other specified csl', async () => {
     suppressBibliography: true,
     csl: 'chicago',
   })
-  const expected = dedent`<div><span class="" id="citation-1">Nash (1950)</span></div>`
+  const expected = dedent`<div><span class="" id="citation-nash1950-1">Nash (1950)</span></div>`
   assert.is(result, expected)
 })
 
@@ -82,7 +82,7 @@ rehypeCitationTest('process HTML code', async () => {
   const result = await processHtml('<div>@verma-rubin</div>', {
     suppressBibliography: true,
   })
-  const expected = dedent`<div><span class="" id="citation-1">Verma &#x26; Rubin (2018)</span></div>`
+  const expected = dedent`<div><span class="" id="citation-verma-rubin-1">Verma &#x26; Rubin (2018)</span></div>`
   assert.is(result, expected)
 })
 
@@ -91,13 +91,13 @@ rehypeCitationTest('supports csl from path', async () => {
     suppressBibliography: true,
     csl: './csl/chicago.csl',
   })
-  const expected = dedent`<div><span class="" id="citation-1">Nash (1950)</span></div>`
+  const expected = dedent`<div><span class="" id="citation-nash1950-1">Nash (1950)</span></div>`
   assert.is(result, expected)
 })
 
 rehypeCitationTest('parse li', async () => {
   const result = await processHtml('<ul><li>@Nash1950</li></ul>', { suppressBibliography: true })
-  const expected = dedent`<ul><li><span class="" id="citation-1">Nash (1950)</span></li></ul>`
+  const expected = dedent`<ul><li><span class="" id="citation-nash1950-1">Nash (1950)</span></li></ul>`
   assert.is(result, expected)
 })
 
@@ -115,13 +115,13 @@ rehypeCitationTest('handle prefix, suffix and locator', async () => {
   const result = await processHtml(dedent`<div>[see @Nash1950, 5-6 suffix]</div>`, {
     suppressBibliography: true,
   })
-  const expected = dedent`<div><span class="" id="citation-1">(see Nash, 1950, pp. 5–6 suffix)</span></div>`
+  const expected = dedent`<div><span class="" id="citation-nash1950-1">(see Nash, 1950, pp. 5–6 suffix)</span></div>`
   assert.is(result, expected)
 })
 
 rehypeCitationTest('suppress author', async () => {
   const result = await processHtml(dedent`<div>[-@Nash1950]</div>`, { suppressBibliography: true })
-  const expected = dedent`<div><span class="" id="citation-1">(1950)</span></div>`
+  const expected = dedent`<div><span class="" id="citation-nash1950-1">(1950)</span></div>`
   assert.is(result, expected)
 })
 
@@ -144,7 +144,7 @@ rehypeCitationTest('works with csl-json', async () => {
     { suppressBibliography: true },
     cslJSON
   )
-  const expected = dedent`<div><span class="" id="citation-1">(Hall, 1957)</span></div>`
+  const expected = dedent`<div><span class="" id="citation-q23571040-1">(Hall, 1957)</span></div>`
   assert.is(result, expected)
 })
 
@@ -154,7 +154,7 @@ rehypeCitationTest('works with url bibliography path', async () => {
     { suppressBibliography: true },
     'https://raw.githubusercontent.com/retorquere/zotero-better-bibtex/v6.0.0/test/fixtures/import/Author%20splitter%20failure.bib'
   )
-  const expected = dedent`<div><span class="" id="citation-1">(Abu-Zeid et al., 1986)</span></div>`
+  const expected = dedent`<div><span class="" id="citation-abu-zeid_1986-1">(Abu-Zeid et al., 1986)</span></div>`
   assert.is(result, expected)
 })
 
@@ -176,7 +176,7 @@ rehypeCitationTest('works with an inline class', async () => {
     suppressBibliography: true,
     inlineClass: ['testClass'],
   })
-  const expected = dedent`<div><span class="testClass" id="citation-1">(Nash, 1950)</span></div>`
+  const expected = dedent`<div><span class="testClass" id="citation-nash1950-1">(Nash, 1950)</span></div>`
   assert.is(result, expected)
 })
 
@@ -185,7 +185,7 @@ rehypeCitationTest('works with multiple inline classes', async () => {
     suppressBibliography: true,
     inlineClass: ['testClass', 'testClass2'],
   })
-  const expected = dedent`<div><span class="testClass testClass2" id="citation-1">(Nash, 1950)</span></div>`
+  const expected = dedent`<div><span class="testClass testClass2" id="citation-nash1950-1">(Nash, 1950)</span></div>`
   assert.is(result, expected)
 })
 


### PR DESCRIPTION
Closes #8.

Add `options.inlineClass` for users to add classes to inline citation elements.
Add `id` to inline citation (`citation-{citekey}-{id}`) and bibliographic elements (`bib-{citekey}`).