### PR TITLE
Feat: accept local file path or URL for CSL and locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,14 +105,14 @@ Required, path to file. Will be joined with `options.bibliography` and `options.
 Type: `'apa'|'vancouver'|'harvard1'|'chicago'|'mla'|string`.
 Default: `apa`.
 
-For the main `rehypeCitation` plugin, one of 'apa', 'vancouver', 'harvard1', 'chicago', 'mla'. A local file path or URL to valid CSL file is also accepted.
+For the main `rehypeCitation` plugin, one of 'apa', 'vancouver', 'harvard1', 'chicago', 'mla'. A local file path or URL to a valid CSL file is also accepted.
 
 #### options.lang
 
 Type: `string`.
 Default: `en-US`.
 
-Locale to use in formatting citations. Defaults to `en-US`. A local file path or URL to valid locale file is also accepted.
+Locale to use in formatting citations. Defaults to `en-US`. A local file path or URL to a valid locale file is also accepted.
 
 #### options.suppressBibliography
 

--- a/README.md
+++ b/README.md
@@ -105,14 +105,14 @@ Required, path to file. Will be joined with `options.bibliography` and `options.
 Type: `'apa'|'vancouver'|'harvard1'|'chicago'|'mla'|string`.
 Default: `apa`.
 
-For the main `rehypeCitation` plugin, one of 'apa', 'vancouver', 'harvard1', 'chicago', 'mla' or name of the local csl file.
+For the main `rehypeCitation` plugin, one of 'apa', 'vancouver', 'harvard1', 'chicago', 'mla'. A local file path or URL to valid CSL file is also accepted.
 
 #### options.lang
 
 Type: `string`.
 Default: `en-US`.
 
-Locale to use in formatting citations. Defaults to `en-US`.
+Locale to use in formatting citations. Defaults to `en-US`. A local file path or URL to valid locale file is also accepted.
 
 #### options.suppressBibliography
 

--- a/src/generator.js
+++ b/src/generator.js
@@ -11,9 +11,9 @@
  * @property {string} [path]
  *   Optional path to file (node). Will be joined with `options.bibliography` and used in place of cwd of file if provided.
  * @property {'apa'|'vancouver'|'harvard1'|'chicago'|'mla'|string} [csl]
- *   One of 'apa', 'vancouver', 'harvard1', 'chicago', 'mla' or name of the local csl file
+ *   One of 'apa', 'vancouver', 'harvard1', 'chicago', 'mla'. A local file path or URL to valid CSL file is also accepted.
  * @property {string} [lang]
- *   Locale to use in formatting citations. Defaults to en-US.
+ *   Locale to use in formatting citations. Defaults to en-US. A local file path or URL to valid locale file is also accepted.
  * @property {boolean} [suppressBibliography]
  *   By default, biliography is inserted after the entire markdown file.
  *   If the file contains `[^Ref]`, the biliography will be inserted there instead.

--- a/src/generator.js
+++ b/src/generator.js
@@ -29,7 +29,7 @@ import { visit } from 'unist-util-visit'
 import fetch from 'cross-fetch'
 import { parseCitation } from './parse-citation.js'
 import { citeExtractorRe } from './regex.js'
-import { isNode, isValidHttpUrl, readFile, getBibliography, loadCSL } from './utils.js'
+import { isNode, isValidHttpUrl, readFile, getBibliography, loadCSL, loadLocale } from './utils.js'
 import { htmlToHast } from './html-transform-node.js'
 
 const defaultCiteFormat = 'apa'
@@ -119,8 +119,10 @@ const rehypeCitationGenerator = (Cite) => {
       let bibtexFile
       /** @type {string} */ // @ts-ignore
       const inputCiteformat = options.csl || file?.data?.frontmatter?.csl || defaultCiteFormat
+      const inputLang = options.lang || 'en-US'
       const config = Cite.plugins.config.get('@csl')
-      const citeFormat = await loadCSL(Cite, inputCiteformat)
+      const citeFormat = await loadCSL(Cite, inputCiteformat, options.path)
+      const lang = await loadLocale(Cite, inputLang, options.path)
 
       if (isValidHttpUrl(bibliography)) {
         isNode
@@ -138,7 +140,7 @@ const rehypeCitationGenerator = (Cite) => {
       const citationIds = citations.data.map((x) => x.id)
       const citationPre = []
       let citationId = 1
-      const citeproc = config.engine(citations.data, citeFormat, options.lang || 'en-US', 'html')
+      const citeproc = config.engine(citations.data, citeFormat, lang, 'html')
       visit(tree, 'text', (node, idx, parent) => {
         const match = node.value.match(citeExtractorRe)
         //@ts-ignore

--- a/src/generator.js
+++ b/src/generator.js
@@ -11,9 +11,9 @@
  * @property {string} [path]
  *   Optional path to file (node). Will be joined with `options.bibliography` and used in place of cwd of file if provided.
  * @property {'apa'|'vancouver'|'harvard1'|'chicago'|'mla'|string} [csl]
- *   One of 'apa', 'vancouver', 'harvard1', 'chicago', 'mla'. A local file path or URL to valid CSL file is also accepted.
+ *   One of 'apa', 'vancouver', 'harvard1', 'chicago', 'mla'. A local file path or URL to a valid CSL file is also accepted.
  * @property {string} [lang]
- *   Locale to use in formatting citations. Defaults to en-US. A local file path or URL to valid locale file is also accepted.
+ *   Locale to use in formatting citations. Defaults to en-US. A local file path or URL to a valid locale file is also accepted.
  * @property {boolean} [suppressBibliography]
  *   By default, biliography is inserted after the entire markdown file.
  *   If the file contains `[^Ref]`, the biliography will be inserted there instead.

--- a/src/utils.js
+++ b/src/utils.js
@@ -65,9 +65,9 @@ export const getBibliography = async (options, file) => {
 }
 
 /**
- * Load CSL - supports predefined list as given from config, http, file path (nodejs)
+ * Load CSL - supports predefined name from config.templates.data or http, file path (nodejs)
  *
- * @param {*} Cite cite object from citation-js configured with the required CSLs
+ * @param {*} Cite cite object from citation-js
  * @param {string} format CSL name e.g. apa or file path to CSL file
  * @param {string} root optional root path
  */
@@ -91,9 +91,9 @@ export const loadCSL = async (Cite, format, root = '') => {
 }
 
 /**
- * Load Locale - supports predefined list as given from config, http, file path (nodejs)
+ * Load locale - supports predefined name from config.locales.data or http, file path (nodejs)
  *
- * @param {*} Cite cite object from citation-js configured with the required locale
+ * @param {*} Cite cite object from citation-js
  * @param {string} format locale name
  * @param {string} root optional root path
  */

--- a/src/utils.js
+++ b/src/utils.js
@@ -63,3 +63,31 @@ export const getBibliography = async (options, file) => {
 
   return bibliography
 }
+
+/**
+ * Load CSL if it is a file path
+ *
+ * @param {*} Cite cite object from citation-js configured with the required CSLs
+ * @param {string} format CSL name e.g. apa or file path to CSL file
+ * @param {string} root optional root path
+ */
+export const loadCSL = async (Cite, format, root = '') => {
+  const config = Cite.plugins.config.get('@csl')
+  if (!Object.keys(config.templates.data).includes(format)) {
+    let cslPath = ''
+    if (isValidHttpUrl(format)) cslPath = format
+    else {
+      if (isNode) {
+        cslPath = await import('path').then((path) => path.join(root, format))
+      }
+    }
+    try {
+      config.templates.add('customCSL', await readFile(cslPath))
+    } catch (err) {
+      throw new Error(`Input CSL option, ${format}, is invalid or is an unknown file.`)
+    }
+    return 'customCSL'
+  } else {
+    return format
+  }
+}

--- a/test/bg-BG.xml
+++ b/test/bg-BG.xml
@@ -1,0 +1,617 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="bg-BG">
+  <info>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+    <updated>2018-02-15T04:14:02+00:00</updated>
+    <translator>
+      <name>Valeriya Simeonova</name>
+      <email>simeonova@fmi.uni-sofia.bg</email>
+      <uri>http://www.mendeley.com/profiles/valeriya-simeonova/</uri>
+    </translator>
+  </info>
+  <style-options punctuation-in-quote="false"/>
+  <date form="text">
+    <date-part name="day" form="numeric-leading-zeros" suffix=" "/>
+    <date-part name="month" suffix=" "/>
+    <date-part name="year"/>
+  </date>
+  <date form="numeric">
+    <date-part name="day" form="numeric-leading-zeros" suffix="."/>
+    <date-part name="month" form="numeric-leading-zeros" suffix="."/>
+    <date-part name="year"/>
+  </date>
+  <terms>
+    <term name="advance-online-publication">advance online publication</term>
+    <term name="album">album</term>
+    <term name="audio-recording">audio recording</term>
+    <term name="film">film</term>
+    <term name="henceforth">henceforth</term>
+    <term name="loc-cit">loc. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
+    <term name="no-place">no place</term>
+    <term name="no-place" form="short">n.p.</term>
+    <term name="no-publisher">no publisher</term> <!-- sine nomine -->
+    <term name="no-publisher" form="short">n.p.</term>
+    <term name="on">on</term>
+    <term name="op-cit">op. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
+    <term name="original-work-published">original work published</term>
+    <term name="personal-communication">лична комуникация</term>
+    <term name="podcast">podcast</term>
+    <term name="podcast-episode">podcast episode</term>
+    <term name="preprint">preprint</term>
+    <term name="radio-broadcast">radio broadcast</term>
+    <term name="radio-series">radio series</term>
+    <term name="radio-series-episode">radio series episode</term>
+    <term name="special-issue">special issue</term>
+    <term name="special-section">special section</term>
+    <term name="television-broadcast">television broadcast</term>
+    <term name="television-series">television series</term>
+    <term name="television-series-episode">television series episode</term>
+    <term name="video">video</term>
+    <term name="working-paper">working paper</term>
+    <term name="accessed">отворен на</term>
+    <term name="and">и</term>
+    <term name="and others">и други</term>
+    <term name="anonymous">анонимен</term>
+    <term name="anonymous" form="short">анон.</term>
+    <term name="at">в</term>
+    <term name="available at">достъпен на</term>
+    <term name="by">от</term>
+    <term name="circa">около</term>
+    <term name="circa" form="short">ок.</term>
+    <term name="cited">цитиран</term>
+    <term name="edition">
+      <single>издание</single>
+      <multiple>издания</multiple>
+    </term>
+    <term name="edition" form="short">изд.</term>
+    <term name="et-al">и съавт.</term>
+    <term name="forthcoming">предстоящ</term>
+    <term name="from">от</term>
+    <term name="ibid">пак там</term>
+    <term name="in">в</term>
+    <term name="in press">под печат</term>
+    <term name="internet">интернет</term>
+    <term name="interview">интервю</term>
+    <term name="letter">писмо</term>
+    <term name="no date">без дата</term>
+    <term name="no date" form="short">б.д.</term>
+    <term name="online">онлайн</term>
+    <term name="presented at">представен на</term>
+    <term name="reference">
+      <single>източник</single>
+      <multiple>източници</multiple>
+    </term>
+    <term name="reference" form="short">
+      <single>изт.</single>
+      <multiple>изт.</multiple>
+    </term>
+    <term name="retrieved">изтеглен на</term>
+    <term name="scale">скала</term>
+    <term name="version">версия</term>
+
+    <!-- LONG ITEM TYPE FORMS -->
+    <term name="article">preprint</term>
+    <term name="article-journal">journal article</term>
+    <term name="article-magazine">magazine article</term>
+    <term name="article-newspaper">newspaper article</term>
+    <term name="bill">bill</term>
+    <term name="book">book</term>
+    <term name="broadcast">broadcast</term>
+    <term name="chapter">book chapter</term>
+    <term name="classic">classic</term>
+    <term name="collection">collection</term>
+    <term name="dataset">dataset</term>
+    <term name="document">document</term>
+    <term name="entry">entry</term>
+    <term name="entry-dictionary">dictionary entry</term>
+    <term name="entry-encyclopedia">encyclopedia entry</term>
+    <term name="event">event</term>
+    <!-- figure is in the list of locator terms -->
+    <term name="graphic">graphic</term>
+    <term name="hearing">hearing</term>
+    <term name="interview">interview</term>
+    <term name="legal_case">legal case</term>
+    <term name="legislation">legislation</term>
+    <term name="manuscript">manuscript</term>
+    <term name="map">map</term>
+    <term name="motion_picture">video recording</term>
+    <term name="musical_score">musical score</term>
+    <term name="pamphlet">pamphlet</term>
+    <term name="paper-conference">conference paper</term>
+    <term name="patent">patent</term>
+    <term name="performance">performance</term>
+    <term name="periodical">periodical</term>
+    <term name="personal_communication">лична комуникация</term>
+    <term name="post">post</term>
+    <term name="post-weblog">blog post</term>
+    <term name="regulation">regulation</term>
+    <term name="report">report</term>
+    <term name="review">review</term>
+    <term name="review-book">book review</term>
+    <term name="software">software</term>
+    <term name="song">audio recording</term>
+    <term name="speech">presentation</term>
+    <term name="standard">standard</term>
+    <term name="thesis">thesis</term>
+    <term name="treaty">treaty</term>
+    <term name="webpage">webpage</term>
+
+    <!-- SHORT ITEM TYPE FORMS -->
+    <term name="article-journal" form="short">journal art.</term>
+    <term name="article-magazine" form="short">mag. art.</term>
+    <term name="article-newspaper" form="short">newspaper art.</term>
+    <term name="book" form="short">bk.</term>
+    <term name="chapter" form="short">bk. chap.</term>
+    <term name="document" form="short">doc.</term>
+    <!-- figure is in the list of locator terms -->
+    <term name="graphic" form="short">graph.</term>
+    <term name="interview" form="short">interv.</term>
+    <term name="manuscript" form="short">MS</term>
+    <term name="motion_picture" form="short">video rec.</term>
+    <term name="report" form="short">rep.</term>
+    <term name="review" form="short">rev.</term>
+    <term name="review-book" form="short">bk. rev.</term>
+    <term name="song" form="short">audio rec.</term>
+
+    <!-- HISTORICAL ERA TERMS -->
+    <term name="ad">сл.хр.</term>
+    <term name="bc">пр.хр.</term>
+    <term name="bce">BCE</term>
+    <term name="ce">CE</term>
+
+    <!-- PUNCTUATION -->
+    <term name="open-quote">„</term>
+    <term name="close-quote">“</term>
+    <term name="open-inner-quote">„</term>
+    <term name="close-inner-quote">“</term>
+    <term name="page-range-delimiter">–</term>
+    <term name="colon">:</term>
+    <term name="comma">,</term>
+    <term name="semicolon">;</term>
+
+    <!-- ORDINALS -->
+    <term name="ordinal">то</term>
+    <term name="ordinal-01">во</term>
+    <term name="ordinal-02">ро</term>
+    <term name="ordinal-03">то</term>
+    <term name="ordinal-21">во</term>
+    <term name="ordinal-22">ро</term>
+    <term name="ordinal-33">то</term>
+    <term name="ordinal" gender-form="masculine">ти</term>
+    <term name="ordinal-01" gender-form="masculine">ви</term>
+    <term name="ordinal-02" gender-form="masculine">ри</term>
+    <term name="ordinal-03" gender-form="masculine">ти</term>
+    <term name="ordinal-21" gender-form="masculine">ви</term>
+    <term name="ordinal-22" gender-form="masculine">ри</term>
+    <term name="ordinal-33" gender-form="masculine">ти</term>
+    <term name="ordinal" gender-form="feminine">та</term>
+    <term name="ordinal-01" gender-form="feminine">ва</term>
+    <term name="ordinal-02" gender-form="feminine">ра</term>
+    <term name="ordinal-03" gender-form="feminine">та</term>
+    <term name="ordinal-21" gender-form="feminine">ва</term>
+    <term name="ordinal-22" gender-form="feminine">ра</term>
+    <term name="ordinal-33" gender-form="feminine">та</term>
+
+    <!-- LONG ORDINALS -->
+    <term name="long-ordinal-01">първo</term>
+    <term name="long-ordinal-02">вторo</term>
+    <term name="long-ordinal-03">третo</term>
+    <term name="long-ordinal-04">четвъртo</term>
+    <term name="long-ordinal-05">петo</term>
+    <term name="long-ordinal-06">шестo</term>
+    <term name="long-ordinal-07">седмo</term>
+    <term name="long-ordinal-08">осмo</term>
+    <term name="long-ordinal-09">деветo</term>
+    <term name="long-ordinal-10">десетo</term>
+    <term name="long-ordinal-01" gender-form="masculine">първи</term>
+    <term name="long-ordinal-02" gender-form="masculine">втори</term>
+    <term name="long-ordinal-03" gender-form="masculine">трети</term>
+    <term name="long-ordinal-04" gender-form="masculine">четверти</term>
+    <term name="long-ordinal-05" gender-form="masculine">пети</term>
+    <term name="long-ordinal-06" gender-form="masculine">шести</term>
+    <term name="long-ordinal-07" gender-form="masculine">седми</term>
+    <term name="long-ordinal-08" gender-form="masculine">осми</term>
+    <term name="long-ordinal-09" gender-form="masculine">девети</term>
+    <term name="long-ordinal-10" gender-form="masculine">десети</term>
+    <term name="long-ordinal-01" gender-form="feminine">първа</term>
+    <term name="long-ordinal-02" gender-form="feminine">втора</term>
+    <term name="long-ordinal-03" gender-form="feminine">трета</term>
+    <term name="long-ordinal-04" gender-form="feminine">четверта</term>
+    <term name="long-ordinal-05" gender-form="feminine">пета</term>
+    <term name="long-ordinal-06" gender-form="feminine">шеста</term>
+    <term name="long-ordinal-07" gender-form="feminine">седма</term>
+    <term name="long-ordinal-08" gender-form="feminine">осма</term>
+    <term name="long-ordinal-09" gender-form="feminine">девета</term>
+    <term name="long-ordinal-10" gender-form="feminine">десета</term>
+
+    <!-- LONG LOCATOR FORMS -->
+    <term name="act">			 
+      <single>act</single>
+      <multiple>acts</multiple>						 
+    </term>
+    <term name="appendix">			 
+      <single>appendix</single>
+      <multiple>appendices</multiple>						 
+    </term>
+    <term name="article-locator">			 
+      <single>article</single>
+      <multiple>articles</multiple>						 
+    </term>
+    <term name="canon">			 
+      <single>canon</single>
+      <multiple>canons</multiple>						 
+    </term>
+    <term name="elocation">			 
+      <single>location</single>
+      <multiple>locations</multiple>						 
+    </term>
+    <term name="equation">			 
+      <single>equation</single>
+      <multiple>equations</multiple>						 
+    </term>
+    <term name="rule">			 
+      <single>rule</single>
+      <multiple>rules</multiple>						 
+    </term>
+    <term name="scene">			 
+      <single>scene</single>
+      <multiple>scenes</multiple>						 
+    </term>
+    <term name="table">			 
+      <single>table</single>
+      <multiple>tables</multiple>						 
+    </term>
+    <term name="timestamp"> <!-- generally blank -->
+      <single></single>
+      <multiple></multiple>						 
+    </term>
+    <term name="title-locator">			 
+      <single>title</single>
+      <multiple>titles</multiple>						 
+    </term>
+    <term name="book">
+      <single>книга</single>
+      <multiple>книги</multiple>
+    </term>
+    <term name="chapter">
+      <single>глава</single>
+      <multiple>глави</multiple>
+    </term>
+    <term name="column">
+      <single>колона</single>
+      <multiple>колони</multiple>
+    </term>
+    <term name="figure">
+      <single>фигура</single>
+      <multiple>фигури</multiple>
+    </term>
+    <term name="folio">
+      <single>фолио</single>
+      <multiple>фолия</multiple>
+    </term>
+    <term name="issue">
+      <single>брой</single>
+      <multiple>броеве</multiple>
+    </term>
+    <term name="line">
+      <single>ред</single>
+      <multiple>редове</multiple>
+    </term>
+    <term name="note">
+      <single>бележка</single>
+      <multiple>бележки</multiple>
+    </term>
+    <term name="opus">
+      <single>опус</single>
+      <multiple>опуси</multiple>
+    </term>
+    <term name="page">
+      <single>страница</single>
+      <multiple>страници</multiple>
+    </term>
+    <term name="number-of-pages">брой страници</term>
+    <term name="paragraph">
+      <single>абзац</single>
+      <multiple>абзаци</multiple>
+    </term>
+    <term name="part">
+      <single>част</single>
+      <multiple>части</multiple>
+    </term>
+    <term name="section">
+      <single>раздел</single>
+      <multiple>раздели</multiple>
+    </term>
+    <term name="sub-verbo">
+      <single>под раздел</single>
+      <multiple>под раздели</multiple>
+    </term>
+    <term name="verse">
+      <single>стихотворение</single>
+      <multiple>стихове</multiple>
+    </term>
+    <term name="volume">
+      <single>том</single>
+      <multiple>томове</multiple>
+    </term>
+
+    <!-- SHORT LOCATOR FORMS -->
+    <term name="appendix">			 
+      <single>app.</single>
+      <multiple>apps.</multiple>						 
+    </term>
+    <term name="article-locator">			 
+      <single>art.</single>
+      <multiple>arts.</multiple>
+    </term>
+    <term name="elocation">			 
+      <single>loc.</single>
+      <multiple>locs.</multiple>
+    </term>
+    <term name="equation">			 
+      <single>eq.</single>
+      <multiple>eqs.</multiple>
+    </term>
+    <term name="rule">			 
+      <single>r.</single>
+      <multiple>rr.</multiple>						 
+    </term>
+    <term name="scene">			 
+      <single>sc.</single>
+      <multiple>scs.</multiple>						 
+    </term>
+    <term name="table">			 
+      <single>tbl.</single>
+      <multiple>tbls.</multiple>						 
+    </term>
+    <term name="timestamp"> <!-- generally blank -->
+      <single></single>
+      <multiple></multiple>						 
+    </term>
+    <term name="title-locator">			 
+      <single>tit.</single>
+      <multiple>tits.</multiple>
+    </term>
+    <term name="book" form="short">кн.</term>
+    <term name="chapter" form="short">гл.</term>
+    <term name="column" form="short">кол.</term>
+    <term name="figure" form="short">фиг.</term>
+    <term name="folio" form="short">фол.</term>
+    <term name="issue" form="short">бр.</term>
+    <term name="line" form="short">р.</term>
+    <term name="note" form="short">бел.</term>
+    <term name="opus" form="short">оп.</term>
+    <term name="page" form="short">стр.</term>
+    <term name="number-of-pages" form="short">бр.стр.</term>
+    <term name="paragraph" form="short">абз.</term>
+    <term name="part" form="short">ч.</term>
+    <term name="section" form="short">разд.</term>
+    <term name="sub-verbo" form="short">подразд.</term>
+    <term name="verse" form="short">ст.</term>
+    <term name="volume" form="short">
+      <single>том</single>
+      <multiple>томове</multiple>
+    </term>
+
+    <!-- SYMBOL LOCATOR FORMS -->
+    <term name="paragraph" form="symbol">
+      <single>¶</single>
+      <multiple>¶¶</multiple>
+    </term>
+    <term name="section" form="symbol">
+      <single>§</single>
+      <multiple>§§</multiple>
+    </term>
+
+    <!-- LONG ROLE FORMS -->
+    <term name="chair">
+      <single>chair</single>
+      <multiple>chairs</multiple>
+    </term>
+    <term name="compiler">
+      <single>compiler</single>
+      <multiple>compilers</multiple>
+    </term>
+    <term name="contributor">
+      <single>contributor</single>
+      <multiple>contributors</multiple>
+    </term>
+    <term name="curator">
+      <single>curator</single>
+      <multiple>curators</multiple>
+    </term>
+    <term name="executive-producer">
+      <single>executive producer</single>
+      <multiple>executive producers</multiple>
+    </term>
+    <term name="guest">
+      <single>guest</single>
+      <multiple>guests</multiple>
+    </term>
+    <term name="host">
+      <single>host</single>
+      <multiple>hosts</multiple>
+    </term>
+    <term name="narrator">
+      <single>narrator</single>
+      <multiple>narrators</multiple>
+    </term>
+    <term name="organizer">
+      <single>organizer</single>
+      <multiple>organizers</multiple>
+    </term>
+    <term name="performer">
+      <single>performer</single>
+      <multiple>performers</multiple>
+    </term>
+    <term name="producer">
+      <single>producer</single>
+      <multiple>producers</multiple>
+    </term>
+    <term name="script-writer">
+      <single>writer</single>
+      <multiple>writers</multiple>
+    </term>
+    <term name="series-creator">
+      <single>series creator</single>
+      <multiple>series creators</multiple>
+    </term>
+    <term name="director">режисьор</term>
+    <term name="editor">
+      <single>редактор</single>
+      <multiple>редактори</multiple>
+    </term>
+    <term name="editorial-director">
+      <single>главен редактор</single>
+      <multiple>редакторски колектив</multiple>
+    </term>
+    <term name="illustrator">илюстрации</term>
+    <term name="translator">
+      <single>преводач</single>
+      <multiple>преводачи</multiple>
+    </term>
+    <term name="editortranslator">
+      <single>editor &amp; translator</single>
+      <multiple>editors &amp; translators</multiple>
+    </term>
+
+    <!-- SHORT ROLE FORMS -->
+    <term name="compiler" form="short">
+      <single>comp.</single>
+      <multiple>comps.</multiple>
+    </term>
+    <term name="contributor" form="short">
+      <single>contrib.</single>
+      <multiple>contribs.</multiple>
+    </term>
+    <term name="curator" form="short">
+      <single>cur.</single>
+      <multiple>curs.</multiple>
+    </term>
+    <term name="executive-producer" form="short">
+      <single>exec. prod.</single>
+      <multiple>exec. prods.</multiple>
+    </term>
+    <term name="narrator" form="short">
+      <single>narr.</single>
+      <multiple>narrs.</multiple>
+    </term>
+    <term name="organizer" form="short">
+      <single>org.</single>
+      <multiple>orgs.</multiple>
+    </term>
+    <term name="performer" form="short">
+      <single>perf.</single>
+      <multiple>perfs.</multiple>
+    </term>
+    <term name="producer" form="short">
+      <single>prod.</single>
+      <multiple>prods.</multiple>
+    </term>
+    <term name="script-writer" form="short">
+      <single>writ.</single>
+      <multiple>writs.</multiple>
+    </term>
+    <term name="series-creator" form="short">
+      <single>cre.</single>
+      <multiple>cres.</multiple>
+    </term>
+    <term name="director" form="short">реж.</term>
+    <term name="editor" form="short">
+      <single>ред.</single>
+      <multiple>ред.кол.</multiple>
+    </term>
+    <term name="editorial-director" form="short">
+      <single>гл.ред.</single>
+      <multiple>гл.ред.кол.</multiple>
+    </term>
+    <term name="illustrator" form="short">ил.</term>
+    <term name="translator" form="short">
+      <single>прев</single>
+      <multiple>прев.кол.</multiple>
+    </term>
+    <term name="editortranslator" form="short">
+      <single>ред. &amp; прев.</single>
+      <multiple>ред.кол. &amp; прев.</multiple>
+    </term>
+
+    <!-- VERB ROLE FORMS -->
+    <term name="chair" form="verb">chaired by</term>
+    <term name="compiler" form="verb">compiled by</term>
+    <term name="contributor" form="verb">with</term>
+    <term name="curator" form="verb">curated by</term>
+    <term name="executive-producer" form="verb">executive produced by</term>
+    <term name="guest" form="verb">with guest</term>
+    <term name="host" form="verb">hosted by</term>
+    <term name="narrator" form="verb">narrated by</term>
+    <term name="organizer" form="verb">organized by</term>
+    <term name="performer" form="verb">performed by</term>
+    <term name="producer" form="verb">produced by</term>
+    <term name="script-writer" form="verb">written by</term>
+    <term name="series-creator" form="verb">created by</term>
+    <term name="container-author" form="verb">от</term>
+    <term name="director" form="verb">под общата редакция на</term>
+    <term name="editor" form="verb">редактиран от</term>
+    <term name="editorial-director" form="verb">главен редактор</term>
+    <term name="illustrator" form="verb">илюстрации от</term>
+    <term name="interviewer" form="verb">интервюиран от</term>
+    <term name="recipient" form="verb">до</term>
+    <term name="reviewed-author" form="verb">рецензент</term>
+    <term name="translator" form="verb">преведен от</term>
+    <term name="editortranslator" form="verb">редактирано &amp; преведено от</term>
+
+    <!-- SHORT VERB ROLE FORMS -->
+    <term name="compiler" form="verb-short">comp. by</term>
+    <term name="contributor" form="verb-short">w.</term>
+    <term name="curator" form="verb-short">cur. by</term>
+    <term name="executive-producer" form="verb-short">exec. prod. by</term>
+    <term name="guest" form="verb-short">w. guest</term>
+    <term name="host" form="verb-short">hosted by</term>
+    <term name="narrator" form="verb-short">narr. by</term>
+    <term name="organizer" form="verb-short">org. by</term>
+    <term name="performer" form="verb-short">perf. by</term>
+    <term name="producer" form="verb-short">prod. by</term>
+    <term name="script-writer" form="verb-short">writ. by</term>
+    <term name="series-creator" form="verb-short">cre. by</term>
+    <term name="director" form="verb-short">п.о.р.</term>
+    <term name="editor" form="verb-short">ред.</term>
+    <term name="editorial-director" form="verb-short">гл.ред.</term>
+    <term name="illustrator" form="verb-short">ил.</term>
+    <term name="translator" form="verb-short">прев.</term>
+    <term name="editortranslator" form="verb-short">ред. &amp; прев. от</term>
+
+    <!-- LONG MONTH FORMS -->
+    <term name="month-01">Януари</term>
+    <term name="month-02">Февруари</term>
+    <term name="month-03">Март</term>
+    <term name="month-04">Април</term>
+    <term name="month-05">Май</term>
+    <term name="month-06">Юни</term>
+    <term name="month-07">Юли</term>
+    <term name="month-08">Август</term>
+    <term name="month-09">Септември</term>
+    <term name="month-10">Октомври</term>
+    <term name="month-11">Ноември</term>
+    <term name="month-12">Декември</term>
+
+    <!-- SHORT MONTH FORMS -->
+    <term name="month-01" form="short">Яну</term>
+    <term name="month-02" form="short">Фев</term>
+    <term name="month-03" form="short">Мар</term>
+    <term name="month-04" form="short">Апр</term>
+    <term name="month-05" form="short">Май</term>
+    <term name="month-06" form="short">Юни</term>
+    <term name="month-07" form="short">Юли</term>
+    <term name="month-08" form="short">Авг</term>
+    <term name="month-09" form="short">Сеп</term>
+    <term name="month-10" form="short">Окт</term>
+    <term name="month-11" form="short">Ное</term>
+    <term name="month-12" form="short">Дек</term>
+
+    <!-- SEASONS -->
+    <term name="season-01">Пролет</term>
+    <term name="season-02">Лято</term>
+    <term name="season-03">Есен</term>
+    <term name="season-04">Зима</term>
+  </terms>
+</locale>

--- a/test/index.js
+++ b/test/index.js
@@ -86,13 +86,35 @@ rehypeCitationTest('process HTML code', async () => {
   assert.is(result, expected)
 })
 
-rehypeCitationTest('supports csl from path', async () => {
-  const result = await processHtml('<div>@Nash1950</div>', {
+rehypeCitationTest('supports csl from local path', async () => {
+  const result = await processHtml('<div>[@Nash1950]</div>', {
     suppressBibliography: true,
-    csl: './csl/chicago.csl',
+    csl: './test/nature.csl',
   })
-  const expected = dedent`<div><span class="" id="citation--nash1950--1">Nash (1950)</span></div>`
+  const expected = dedent`<div><span class="" id="citation--nash1950--1"><sup>1</sup></span></div>`
   assert.is(result, expected)
+})
+
+rehypeCitationTest('supports csl from url', async () => {
+  const result = await processHtml('<div>[@Nash1950]</div>', {
+    suppressBibliography: true,
+    csl: 'https://www.zotero.org/styles/nature',
+  })
+  const expected = dedent`<div><span class="" id="citation--nash1950--1"><sup>1</sup></span></div>`
+  assert.is(result, expected)
+})
+
+rehypeCitationTest('throw error if invalid csl', async () => {
+  try {
+    await processHtml(dedent`<div>[@Nash1950]</div>`, {
+      suppressBibliography: true,
+      csl: 'unknown-csl',
+    })
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.instance(err, Error)
+    assert.match(err.message, `Input CSL option, unknown-csl, is invalid or is an unknown file`)
+  }
 })
 
 rehypeCitationTest('parse li', async () => {
@@ -135,6 +157,7 @@ rehypeCitationTest('throw an error if invalid file path', async () => {
     assert.unreachable('should have thrown')
   } catch (err) {
     assert.instance(err, Error)
+    assert.is(err.code, 'ENOENT')
   }
 })
 
@@ -168,6 +191,7 @@ rehypeCitationTest('throw error if invalid url path', async () => {
     assert.unreachable('should have thrown')
   } catch (err) {
     assert.instance(err, Error)
+    assert.match(err.message, 'This format is not supported or recognized')
   }
 })
 

--- a/test/index.js
+++ b/test/index.js
@@ -98,7 +98,7 @@ rehypeCitationTest('supports csl from local path', async () => {
 rehypeCitationTest('supports csl from url', async () => {
   const result = await processHtml('<div>[@Nash1950]</div>', {
     suppressBibliography: true,
-    csl: 'https://www.zotero.org/styles/nature',
+    csl: 'https://raw.githubusercontent.com/citation-style-language/locales/master/locales-zh-CN.xml',
   })
   const expected = dedent`<div><span class="" id="citation--nash1950--1"><sup>1</sup></span></div>`
   assert.is(result, expected)
@@ -114,6 +114,37 @@ rehypeCitationTest('throw error if invalid csl', async () => {
   } catch (err) {
     assert.instance(err, Error)
     assert.match(err.message, `Input CSL option, unknown-csl, is invalid or is an unknown file`)
+  }
+})
+
+rehypeCitationTest('supports locale from local path', async () => {
+  const result = await processHtml('<div>[@Nash1950]</div>', {
+    suppressBibliography: true,
+    lang: './test/bg-BG.xml',
+  })
+  const expected = dedent`<div><span class="" id="citation--nash1950--1">(Nash, 1950)</span></div>`
+  assert.is(result, expected)
+})
+
+rehypeCitationTest('supports locale from url', async () => {
+  const result = await processHtml('<div>[@Nash1950]</div>', {
+    suppressBibliography: true,
+    lang: 'https://raw.githubusercontent.com/citation-style-language/locales/master/locales-zh-TW.xml',
+  })
+  const expected = dedent`<div><span class="" id="citation--nash1950--1">(Nash, 1950)</span></div>`
+  assert.is(result, expected)
+})
+
+rehypeCitationTest('throw error if invalid locale', async () => {
+  try {
+    await processHtml(dedent`<div>[@Nash1950]</div>`, {
+      suppressBibliography: true,
+      lang: 'unknown-lang',
+    })
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.instance(err, Error)
+    assert.match(err.message, `Input locale option, unknown-lang, is invalid or is an unknown file`)
   }
 })
 

--- a/test/nature.csl
+++ b/test/nature.csl
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
+  <info>
+    <title>Nature</title>
+    <id>http://www.zotero.org/styles/nature</id>
+    <link href="http://www.zotero.org/styles/nature" rel="self"/>
+    <link href="http://www.nature.com/nature/authors/gta/index.html#a5.4" rel="documentation"/>
+    <link href="http://www.nature.com/srep/publish/guidelines#references" rel="documentation"/>
+    <author>
+      <name>Michael Berkowitz</name>
+      <email>mberkowi@gmu.edu</email>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="science"/>
+    <category field="generic-base"/>
+    <issn>0028-0836</issn>
+    <eissn>1476-4687</eissn>
+    <updated>2019-10-08T13:18:12+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name sort-separator=", " delimiter=", " and="symbol" initialize-with=". " delimiter-precedes-last="never" name-as-sort-order="all"/>
+      <label form="short" prefix=", "/>
+      <et-al font-style="italic"/>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="volume"/>
+      <else-if variable="DOI">
+        <text variable="DOI" prefix="doi:"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="issuance">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture song thesis chapter paper-conference" match="any">
+        <group delimiter="; " suffix=".">
+          <group delimiter=", " prefix="(" suffix=")">
+            <text variable="publisher" form="long"/>
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </group>
+        </group>
+      </if>
+      <else-if type="report webpage post post-weblog" match="any">
+        <group delimiter=" ">
+          <text variable="URL"/>
+          <date date-parts="year" form="text" variable="issued" prefix="(" suffix=")"/>
+        </group>
+      </else-if>
+      <else>
+        <date variable="issued" prefix="(" suffix=")">
+          <date-part name="year"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="article-journal">
+        <text variable="container-title" font-style="italic" form="short"/>
+      </if>
+      <else>
+        <text variable="container-title" font-style="italic"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="editor">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <names variable="editor" prefix="(" suffix=")">
+          <label form="short" suffix=" "/>
+          <name and="symbol" delimiter-precedes-last="never" initialize-with=". " name-as-sort-order="all"/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="volume">
+    <choose>
+      <if type="article-journal" match="any">
+        <text variable="volume" font-weight="bold" suffix=","/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <label variable="volume" form="short"/>
+          <text variable="volume"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout vertical-align="sup" delimiter=",">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <bibliography et-al-min="6" et-al-use-first="1" second-field-align="flush" entry-spacing="0" line-spacing="2">
+    <layout suffix=".">
+      <text variable="citation-number" suffix="."/>
+      <group delimiter=" ">
+        <text macro="author" suffix="."/>
+        <text macro="title" suffix="."/>
+        <choose>
+          <if type="chapter paper-conference" match="any">
+            <text term="in"/>
+          </if>
+        </choose>
+        <text macro="container-title"/>
+        <text macro="editor"/>
+        <text macro="volume"/>
+        <text variable="page"/>
+        <text macro="issuance"/>
+        <text macro="access"/>
+      </group>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
Fix #10 

@chaichontat, let me know if this works for you? As suggested, we will automatically assign a name for a CSL and locale that is provided by path.

I have also fixed it such that it throws an error for a CSL or locale that does not exist in the config.