### PR TITLE
fix: handle more than 1 digit for numeric citations

### DIFF
--- a/src/gen-citation.js
+++ b/src/gen-citation.js
@@ -65,7 +65,7 @@ export const genCitation = (
     // e.g. [1, 2]
     let i = 0
     const refIds = entries.map((e) => e.id)
-    const output = citationText.replace(/\d/g, function (d) {
+    const output = citationText.replace(/\d+/g, function (d) {
       const url = `<a href="#bib-${refIds[i].toLowerCase()}">${d}</a>`
       i++
       return url


### PR DESCRIPTION
Fix regex to detect possibly more than 1 digit

Fix #21