### PR TITLE
fix brackets for styles that do not use parentheses

### DIFF
--- a/src/gen-citation.js
+++ b/src/gen-citation.js
@@ -81,7 +81,7 @@ export const genCitation = (
       // Do not link bracket
       const output = isComposite
         ? `<a href="#bib-${entries[0].id.toLowerCase()}">${citationText}</a>`
-        : `(<a href="#bib-${entries[0].id.toLowerCase()}">${citationText.slice(1, -1)}</a>)`
+        : `${citationText.slice(0,1)}<a href="#bib-${entries[0].id.toLowerCase()}">${citationText.slice(1, -1)}</a>${citationText.slice(-1)}`
       return [
         citationText,
         htmlToHast(`<span class="${(inlineClass ?? []).join(' ')}" id=${ids}>${output}</span>`),


### PR DESCRIPTION
If the csl citation style does not use parentheses the linkCitation option still replaces it with parentheses in a certain case.
This commit fixes #28.