### PR TITLE
fix if node has no child

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -197,6 +197,7 @@ const rehypeCitationGenerator = (Cite) => {
           if (
             !options.suppressBibliography &&
             (node.tagName === 'p' || node.tagName === 'div') &&
+            node.children.length >= 1 &&
             node.children[0].value === '[^ref]'
           ) {
             parent.children[idx] = biblioNode


### PR DESCRIPTION
In case an element of the AST has no children we access an undefined child. This PR tests if children are present before accessing the first.

Fixes #30 