### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "node": "./dist/node/rehype-citation.mjs",
-      "default": "./dist/browser/rehype-citation.mjs"
+      "node": [
+        "./dist/node/rehype-citation.mjs",
+        "./dist/node/index.d.ts"
+      ],
+      "default": [
+        "./dist/browser/rehype-citation.mjs",
+        "./dist/node/index.d.ts"
+      ]
     },
     "./browser/": {
       "default": "./dist/browser/"


### PR DESCRIPTION
Adding `index.d.ts` file to `exports` to solve `vscode` complaining about decalaration file: `There are types at /node_modules/rehype-citation/dist/node/index.d.ts', but this result could not be resolved when respecting package.json "exports". the 'rehype-citation' library may need to update its package.json or typings.`