### PR TITLE
Add the option {generateGraph: false}

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -73,7 +73,7 @@ const rehypeCitationGenerator = (Cite) => {
           }
         }
       }
-      const citations = new Cite(bibtexFile)
+      const citations = new Cite(bibtexFile, {generateGraph: false});
       const citationIds = citations.data.map((x) => x.id)
       const citationPre = []
       const citationDict = {}


### PR DESCRIPTION
The option generateGraph (default: true) generates some graph information with every bibliography item. When dealing with large bib files (1MB in my case), this causes a crash in citeproc-js, precisely here:
https://github.com/Juris-M/citeproc-js/blob/57e3584632fe44db410da1771c4b6bd69fe729f9/src/build.js#L553

The function retrieveItem makes all bib items go through JSON.stringify and JSON.parse. JSON.stringify crashes on big inputs.

Therefore, it is better to use {generateGraph: false}, I don't think we loose any feature as far as rehype-citation is concerned.