### PR TITLE
Fix package json node exports to solve types resolution problem and Bug fix preventing [^ref] from working properly for node. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/node/index.d.ts",
       "node": "./dist/node/rehype-citation.mjs",
       "default": "./dist/browser/rehype-citation.mjs"
     },

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,19 +54,20 @@ export const getBibliography = async (options, file) => {
       typeof file.data.frontmatter.bibliography === 'string'
         ? [file.data.frontmatter.bibliography]
         : file.data.frontmatter.bibliography
-    // If local path, get absolute path
-    for (let i = 0; i < bibliography.length; i++) {
-      if (!isValidHttpUrl(bibliography[i])) {
-        if (isNode) {
-          bibliography[i] = await import('path').then((path) =>
-            path.join(options.path || file.cwd, bibliography[i])
-          )
-        } else {
-          throw new Error(`Cannot read non valid bibliography URL in node env.`)
-        }
+  }   
+  // If local path, get absolute path
+  for (let i = 0; i < bibliography.length; i++) {
+    if (!isValidHttpUrl(bibliography[i])) {
+      if (isNode) {
+        bibliography[i] = await import('path').then((path) =>
+          path.join(options.path || file.cwd, bibliography[i])
+        )
+      } else {
+        throw new Error(`Cannot read non valid bibliography URL in node env.`)
       }
     }
   }
+  
 
   return bibliography
 }


### PR DESCRIPTION
1. Problem with types file index.d.ts:

As per [Node documentation](https://nodejs.org/api/packages.html#nodejs-packagejson-field-definitions) the "types" entry field in package.json isn't used by the node runtime.
On Windows, `vscode` is complaining about decalaration file:

> `There are types at /node_modules/rehype-citation/dist/node/index.d.ts', but this result could not be resolved when respecting package.json "exports". the 'rehype-citation' library may need to update its package.json or typings.`

As shown in [Node documentation](https://nodejs.org/api/packages.html#community-conditions-definitions), 

> Since custom package conditions require clear definitions to ensure correct usage, a list of common known package conditions and their strict definitions is provided below to assist with ecosystem coordination.
> 
> "types" - can be used by typing systems to resolve the typing file for the given export. This condition should always be included first.

So we need to add `index.d.ts` file to `exports` to solve this problem., like below

```json
  "exports": {
    ".": {
    + "types": "./dist/node/index.d.ts",
      "node": "./dist/node/rehype-citation.mjs",
      "default": "./dist/browser/rehype-citation.mjs"
    },
    ...
  }
```

2. Bug: Problem with [^ref] not working on node.
It's seems that the problem is due to a poorly positioned closing curly brace.
 
