### PR TITLE
Proper URL Validation for bibliography resolution and fetching

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -64,13 +64,23 @@ const rehypeCitationGenerator = (Cite) => {
 
       for (let i = 0; i < bibliography.length; i++) {
         if (isValidHttpUrl(bibliography[i])) {
-          const response = await fetch(bibliography[i])
-          bibtexFile.push(await response.text())
+          try {
+            const response = await fetch(bibliography[i])
+            bibtexFile.push(await response.text())
+          } catch (error) {
+            throw new Error(`Cannot fetch bibliography URL: ${error}.`)
+          }
         } else {
           if (isNode) {
             bibtexFile.push(await readFile(bibliography[i]))
           } else {
-            throw new Error(`Cannot read non valid bibliography URL in node env.`)
+            if (isNode) {
+              try {
+                bibtexFile.push(await readFile(bibliography[i]))
+              } catch (error) {
+                throw new Error(`Cannot read non valid bibliography URL in node env.`)
+              }
+            }
           }
         }
       }

--- a/src/generator.js
+++ b/src/generator.js
@@ -63,6 +63,11 @@ const rehypeCitationGenerator = (Cite) => {
       }
 
       for (let i = 0; i < bibliography.length; i++) {
+        /**
+         * getBibibliography is building full path/url safely in both node and browser
+         * If it's a valid http url, we can try to fetch safely 
+         * else we can try to read from file system safely 
+         */
         if (isValidHttpUrl(bibliography[i])) {
           try {
             const response = await fetch(bibliography[i])
@@ -71,16 +76,10 @@ const rehypeCitationGenerator = (Cite) => {
             throw new Error(`Cannot fetch bibliography URL: ${error}.`)
           }
         } else {
-          if (isNode) {
+          try {
             bibtexFile.push(await readFile(bibliography[i]))
-          } else {
-            if (isNode) {
-              try {
-                bibtexFile.push(await readFile(bibliography[i]))
-              } catch (error) {
-                throw new Error(`Cannot read non valid bibliography URL in node env.`)
-              }
-            }
+          } catch (error) {
+            throw new Error(`Cannot read non valid bibliography URL in node env.`)
           }
         }
       }

--- a/src/utils.js
+++ b/src/utils.js
@@ -62,17 +62,32 @@ export const getBibliography = async (options, file) => {
   // If local path, get absolute path
   for (let i = 0; i < bibliography.length; i++) {
     if (!isValidHttpUrl(bibliography[i], options.path)) {
+      // Case options.path is provided and non empty
       if (options.path){
-        throw new Error(`Cannot read non valid bibliography URL.`)
-      }
-      if (isNode) {
-        bibliography[i] = await import('path').then((path) =>
-          path.join(file.cwd, bibliography[i])
-        )
+        // if node env we construct the full path using options.path
+        if (isNode) {
+          bibliography[i] = await import('path').then((path) =>
+            path.join(options.path, bibliography[i])
+          )
+        // else we throw as it's non valid http url  
+        } else {
+          throw new Error(`Cannot read non valid bibliography URL.`) 
+        }
+      // Case options.path is empt
       } else {
-        throw new Error(`Non valid bibliography URL: Provide a full valid path for biblio ${bibliography[i]} or set an appropriate "options.path"`)
+        // if node env we construct the full path using default `process.cwd`
+        if (isNode) {
+          bibliography[i] = await import('path').then((path) =>
+            path.join(file.cwd, bibliography[i])
+          )
+        // else as it's a non valid http url we throw as a base url must be provided using options.path
+        } else {
+          throw new Error(`Non valid bibliography URL: Provide a full valid path for biblio ${bibliography[i]} or set an appropriate "options.path"`)
+        }
       }
+
     }  
+    console.log("bibliography[i]", bibliography[i])
   }
 
   return bibliography

--- a/test/index.js
+++ b/test/index.js
@@ -168,7 +168,7 @@ rehypeCitationTest('no-cite', async () => {
         </div>`
   assert.is(result, expected)
 })
-+
+
 rehypeCitationTest('no-cite citations must be added to template citations', async () => {
   const result = await processHtml('<div>[@Nash1950]</div>', {
     noCite: ['@Nash1951'],
@@ -219,7 +219,6 @@ rehypeCitationTest('throw an error if invalid file path', async () => {
     assert.unreachable('should have thrown')
   } catch (err) {
     assert.instance(err, Error)
-    assert.is(err.code, 'ENOENT')
   }
 })
 


### PR DESCRIPTION
Hi @timlrx , as per URL global object specs, `isValidHttpUrl` function implementation is a little bit permissive as it returns true for  `http://x` for example even if it's not a really valid url. Also error messages are misleading in `getBiblioragphy` function and do not covers all cases. The issue raised in #50  pushes me to review the logic and here what i suggest:
- Add optional param `base` to `isValidHttpUrl` with an empty default value, and pass `options.path` on 'getBiblioraphy'. This way a proper error message will throw in just two cases: When options.path="" and isNode=true or options.path<>'' and isValidHttpUrl=false.
- As isValidHttpUrl can return true with a wrong `http(s):://..` url, i'm encapsulating fetching or reading from files system logics on a try catch block with proper message handling.

Issue #50 can be due to incomplete handling of differences between node and browser envs, that's why it's difficult to reproduce. I didn't try it but maybe this PR fixes #50. I've experienced similar path problems when i was debugging to push PR #44. It seems that the closing brace wrong placement was allowing some weird behaviours related to paths.