### PR TITLE
Allow bibliography as blob/ObjectURL to avoid refetching everytime.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -37,7 +37,7 @@ export const isValidHttpUrl = (str, base = "") => {
     return false
   }
 
-  return url.protocol === 'http:' || url.protocol === 'https:'
+  return url.protocol === 'http:' || url.protocol === 'https:' || url.protocol === 'blob:'
 }
 
 /**


### PR DESCRIPTION
I wanted to avoid refetching the .bib file everytime I change the Markdown (e.g. live-preview for an interactive editor), so I wanted to load the bib file as ObjectURL. However, this raises an error in the package even though objectURLs actually work fine. Now it works nicely for me :) I am a bit of a noob, and I am not sure if this is how you intend this package to be used. But maybe it can be helpful for others?