### PR TITLE
New tooltip feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,17 @@ Type: `boolean`.
 Default: `false`.
 
 If true, citations will be hyperlinked to the corresponding bibliography entries (for author-date and numeric styles only).
+
+#### options.showTooltips
+
+Type: `boolean`.
+Default: `false`.
+
+If true, citations will display tooltips containing the full bibliography entry when hovered. For multiple citations, each reference will have its own tooltip. When used with `linkCitations: true`, tooltips are added to each individual link.
+
+#### options.tooltipAttribute
+
+Type: `string`.
+Default: `title`.
+
+The HTML attribute to use for tooltips. By default, the standard HTML `title` attribute is used, but you can specify an alternative attribute (e.g., `data-tooltip`) for custom tooltip implementations or to work with specific tooltip libraries.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ API and options follows very closely to [Rmarkdown](https://bookdown.org/yihui/r
 - [Custom CSL](https://rehype-citation.netlify.app/custom-csl)
 - [Footnote style](https://rehype-citation.netlify.app/footnote-style)
 - [Link Citations](https://rehype-citation.netlify.app/link-citations)
+- [Tooltips](https://rehype-citation.netlify.app/tooltips)
 
 ## Installation
 

--- a/demo/app/App.jsx
+++ b/demo/app/App.jsx
@@ -8,6 +8,7 @@ import {
   FootnotesExample,
   LinkCitationsExample,
   CFFExample,
+  TooltipExample,
 } from './md-examples'
 
 const bibliography =
@@ -30,6 +31,7 @@ const examples = [
   'Footnote Style',
   'Link Citations',
   'Citation File Format',
+  'Tooltips',
 ]
 const pathList = examples.map((e) => e.toLocaleLowerCase().replace(' ', '-'))
 
@@ -105,6 +107,17 @@ function App() {
             markdown={CFFExample}
             rehypeCitationOptions={{
               bibliography: [cff, cff2, cff3],
+            }}
+          />
+        )}
+        {selected === examples[6] && (
+          <Example
+            markdown={TooltipExample}
+            rehypeCitationOptions={{
+              bibliography,
+              linkCitations: true,
+              showTooltips: true,
+              tooltipAttribute: 'data-tooltip',
             }}
           />
         )}

--- a/demo/app/index.css
+++ b/demo/app/index.css
@@ -9,3 +9,35 @@
 .footnotes {
   @apply mt-4 border-t border-gray-300;
 }
+
+/* Base styles for elements with data-tooltip */
+[data-tooltip] {
+  @apply relative inline-block cursor-pointer;
+}
+
+/* The tooltip element that appears on hover */
+[data-tooltip]::after {
+  @apply absolute invisible opacity-0 
+         bg-gray-800 text-white text-sm rounded-md py-2 px-3
+         w-max max-w-xs break-words text-left z-50
+         left-1/2 transform -translate-x-1/2 bottom-full mb-2
+         shadow-lg transition-opacity duration-200;
+  content: attr(data-tooltip);
+}
+
+/* Arrow for the tooltip */
+[data-tooltip]::before {
+  @apply absolute invisible opacity-0
+         w-0 h-0 z-50
+         left-1/2 transform -translate-x-1/2 bottom-full
+         border-solid border-8 border-transparent border-t-gray-800
+         transition-opacity duration-200;
+  content: '';
+  margin-bottom: -6px;
+}
+
+/* Show tooltip and arrow on hover */
+[data-tooltip]:hover::after,
+[data-tooltip]:hover::before {
+  @apply visible opacity-100;
+}

--- a/demo/app/md-examples.js
+++ b/demo/app/md-examples.js
@@ -94,3 +94,21 @@ To cite, use the DOI reference directly or use the URL without the protocol (htt
 
 ### Bibliography
 `
+
+export const TooltipExample = `## Welcome
+
+Rehype plugin to nicely format citations in markdown
+documents and insert bibliography in html format.
+
+- Supports standard citations [@Nash1950{pp. iv, vi-xi, (xv)-(xvii)}];
+- in-text citations, @Nash1951 [p. 33] says blah;
+- and multiple citations [see @Nash1950 pp 12-13; @Nash1951]
+
+The _showTooltips_ option can be used to show the full bibliography entry as a tooltip on hover. 
+
+The formatting of the tooltip depends on the underlying citation style.
+
+By default, the standard HTML _title_ attribute is used, but you can specify an alternative attribute (e.g., _data-tooltip_) and style it with custom CSS.
+
+### Bibliography
+`

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
       "devDependencies": {
         "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
         "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
-        "@playwright/test": "^1.39.0",
+        "@playwright/test": "^1.51.1",
         "@tailwindcss/typography": "^0.5.9",
         "@types/node": "^20.8.4",
         "@vitejs/plugin-react": "^4.1.0",
@@ -2603,18 +2603,18 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
-      "integrity": "sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.1.tgz",
+      "integrity": "sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.39.0"
+        "playwright": "1.51.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/plugin-alias": {
@@ -8017,33 +8017,33 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
-      "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.1.tgz",
+      "integrity": "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.39.0"
+        "playwright-core": "1.51.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
-      "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
+      "integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   "devDependencies": {
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
     "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
-    "@playwright/test": "^1.39.0",
+    "@playwright/test": "^1.51.1",
     "@tailwindcss/typography": "^0.5.9",
     "@types/node": "^20.8.4",
     "@vitejs/plugin-react": "^4.1.0",

--- a/src/types.js
+++ b/src/types.js
@@ -21,6 +21,11 @@
  *   Class(es) to add to the inline citation.
  * @property {string[]} [inlineBibClass]
  *   Class(es) to add to the inline bibliography. Leave empty for no inline bibliography.
+ *  @property {boolean} [showTooltips]
+ *   If true, citations will show the full bibliography entry as a tooltip on hover.
+ *   @property {string} [tooltipAttribute]
+ *   The HTML attribute to use for tooltips. Can be 'title' or any custom data attribute
+ *   (e.g., 'data-citation-text'). Defaults to 'title'.
  */
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -255,10 +255,28 @@ export const getFrontmatterField = (file, fieldName) => {
  * @return {string} formatted bibliography entry without HTML tags
  */
 export const getBibliographyEntryText = (citeproc, id) => {
-  const [params, bibBody] = citeproc.makeBibliography([id])
-  if (!bibBody || bibBody.length === 0) return ''
-  let entryText = bibBody[0].replace(/<[^>]*>/g, '')
-  entryText = entryText.replace(/\s+/g, ' ').trim()
+  try {
+    // Save the current state
+    const originalItemIds = [...citeproc.registry.mylist]
 
-  return entryText
+    // Since creating bibliography affects the state we need to save the current state and restore it
+    citeproc.updateItems([id])
+    const bibOutput = citeproc.makeBibliography([id])
+    if (!bibOutput || !bibOutput[1] || bibOutput[1].length === 0) {
+      citeproc.updateItems(originalItemIds)
+      return ''
+    }
+
+    // Get the text
+    let entryText = bibOutput[1][0].replace(/<[^>]*>/g, '')
+    entryText = entryText.replace(/\s+/g, ' ').trim()
+
+    // Restore the original state
+    citeproc.updateItems(originalItemIds)
+
+    return entryText
+  } catch (error) {
+    console.error('Error getting bibliography entry text:', error)
+    return ''
+  }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,11 +28,11 @@ export const readFile = async (path) => {
  * @param {string} str
  * @return {boolean}
  */
-export const isValidHttpUrl = (str, base = "") => {
+export const isValidHttpUrl = (str, base = '') => {
   let url
 
   try {
-    url = base ? new URL(str, base): new URL(str)
+    url = base ? new URL(str, base) : new URL(str)
   } catch (_) {
     return false
   }
@@ -63,29 +63,30 @@ export const getBibliography = async (options, file) => {
   for (let i = 0; i < bibliography.length; i++) {
     if (!isValidHttpUrl(bibliography[i], options.path)) {
       // Case options.path is provided and non empty
-      if (options.path){
+      if (options.path) {
         // if node env we construct the full path using options.path
         if (isNode) {
           bibliography[i] = await import('path').then((path) =>
             path.join(options.path, bibliography[i])
           )
-        // else we throw as it's non valid http url  
+          // else we throw as it's non valid http url
         } else {
-          throw new Error(`Cannot read non valid bibliography URL.`) 
+          throw new Error(`Cannot read non valid bibliography URL.`)
         }
-      // Case options.path is empt
+        // Case options.path is empt
       } else {
         // if node env we construct the full path using default `process.cwd`
         if (isNode) {
           bibliography[i] = await import('path').then((path) =>
             path.join(file.cwd, bibliography[i])
           )
-        // else as it's a non valid http url we throw as a base url must be provided using options.path
+          // else as it's a non valid http url we throw as a base url must be provided using options.path
         } else {
-          throw new Error(`Non valid bibliography URL: Provide a full valid path for biblio ${bibliography[i]} or set an appropriate "options.path"`)
+          throw new Error(
+            `Non valid bibliography URL: Provide a full valid path for biblio ${bibliography[i]} or set an appropriate "options.path"`
+          )
         }
       }
-
     }
   }
 
@@ -244,4 +245,20 @@ export const getFrontmatterField = (file, fieldName) => {
   }
 
   return undefined
+}
+
+/**
+ * Get bibliography entry text for a citation ID
+ *
+ * @param {*} citeproc citeproc engine
+ * @param {string} id citation ID
+ * @return {string} formatted bibliography entry without HTML tags
+ */
+export const getBibliographyEntryText = (citeproc, id) => {
+  const [params, bibBody] = citeproc.makeBibliography([id])
+  if (!bibBody || bibBody.length === 0) return ''
+  let entryText = bibBody[0].replace(/<[^>]*>/g, '')
+  entryText = entryText.replace(/\s+/g, ' ').trim()
+
+  return entryText
 }

--- a/test/index.js
+++ b/test/index.js
@@ -180,7 +180,6 @@ rehypeCitationTest('no-cite citations must be added to template citations', asyn
   assert.is(result, expected)
 })
 
-
 rehypeCitationTest('no-cite catch all', async () => {
   const result = await processHtml('<div>text</div>', {
     noCite: ['@*'],
@@ -330,6 +329,65 @@ rehypeCitationTest('parses multiple bibliography files', async () => {
   )
   const expected = dedent`<div><span class="" id="citation--10.5281/zenodo.1234--1">(Lisa &#x26; Bot, 2017)</span> and <span class="" id="citation--nash1950--2">(Nash, 1950)</span></div>`
   assert.is(result, expected)
+})
+
+rehypeCitationTest('adds tooltips to citations when showTooltips is true', async () => {
+  const result = await processHtml(dedent`<div>[@Nash1950]</div>`, {
+    suppressBibliography: true,
+    showTooltips: true,
+  })
+  assert.match(result, /title="Nash, J\. \(1950\)\. Equilibrium points in n-person games\./)
+  assert.match(result, /<span class="" id="citation--nash1950--1" title="[^"]+">/)
+})
+
+rehypeCitationTest('uses custom tooltipAttribute when specified', async () => {
+  const result = await processHtml(dedent`<div>[@Nash1950]</div>`, {
+    suppressBibliography: true,
+    showTooltips: true,
+    tooltipAttribute: 'data-tooltip',
+  })
+  assert.match(result, /data-tooltip="Nash, J\. \(1950\)\. Equilibrium points in n-person games\./)
+  assert.not.match(result, /title="/)
+})
+
+rehypeCitationTest('adds individual tooltips to each link in numeric citations', async () => {
+  const result = await processHtml(dedent`<div>[@Nash1950; @Nash1951]</div>`, {
+    suppressBibliography: true,
+    csl: 'vancouver',
+    linkCitations: true,
+    showTooltips: true,
+  })
+  assert.match(result, /<a href="#bib-nash1950" title=/)
+  assert.match(result, /<a href="#bib-nash1951" title=/)
+})
+
+rehypeCitationTest('adds individual tooltips to each link in author-date citations', async () => {
+  const result = await processHtml(dedent`<div>[@Nash1950; @Nash1951]</div>`, {
+    suppressBibliography: true,
+    linkCitations: true,
+    showTooltips: true,
+  })
+  assert.match(result, /<a href="#bib-nash1950" title=/)
+  assert.match(result, /<a href="#bib-nash1951" title=/)
+  assert.not.match(result, /<span class="" id="citation--nash1950--nash1951--1" title=/)
+})
+
+rehypeCitationTest('adds tooltips when linkCitations is false', async () => {
+  const result = await processHtml(dedent`<div>[@Nash1950; @Nash1951]</div>`, {
+    suppressBibliography: true,
+    showTooltips: true,
+    linkCitations: false,
+  })
+  assert.match(result, /<span class="" id="citation--nash1950--nash1951--1" title=/)
+})
+
+rehypeCitationTest('adds tooltips to note-style citations', async () => {
+  const result = await processHtml(dedent`<div>[@Nash1950]</div>`, {
+    suppressBibliography: true,
+    csl: './test/nature.csl',
+    showTooltips: true,
+  })
+  assert.match(result, /<span class="" id="citation--nash1950--1" title=/)
 })
 
 rehypeCitationTest.run()


### PR DESCRIPTION
# Tooltip

Add `showTooltips` and `tooltipAttribute` option to add an optional inline tooltip to the generated citation entry. The bibliography entry will be inserted at the configured `tooltipAttribute` (default `title`) and is formatted based on the CSL style used.

There's an additional complication adding the tooltip - citeproc is stateful and the bibliography entry might not fully reflect how a tooltip should be formatted e.g. for an an entry with the same author, the bibliography plugin might render a dash instead. Hence the tooltip should just create a single entry and get the bibliography text associated to it. This requires saving the existing state, generated the single entry and restoring the state.

Closes #56