### PR TITLE
fix: remove local path from url construction

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -28,11 +28,11 @@ export const readFile = async (path) => {
  * @param {string} str
  * @return {boolean}
  */
-export const isValidHttpUrl = (str, base = '') => {
+export const isValidHttpUrl = (str) => {
   let url
 
   try {
-    url = base ? new URL(str, base) : new URL(str)
+    url = new URL(str)
   } catch (_) {
     return false
   }
@@ -61,7 +61,7 @@ export const getBibliography = async (options, file) => {
   }
   // If local path, get absolute path
   for (let i = 0; i < bibliography.length; i++) {
-    if (!isValidHttpUrl(bibliography[i], options.path)) {
+    if (!isValidHttpUrl(bibliography[i])) {
       // Case options.path is provided and non empty
       if (options.path) {
         // if node env we construct the full path using options.path

--- a/test/index.js
+++ b/test/index.js
@@ -241,6 +241,16 @@ rehypeCitationTest('works with url bibliography path', async () => {
   assert.is(result, expected)
 })
 
+rehypeCitationTest('url should not be affected by path', async () => {
+  const result = await processHtml(
+    dedent`<div>[@Abu-Zeid_1986]</div>`,
+    { suppressBibliography: true, path: process.cwd() },
+    'https://raw.githubusercontent.com/retorquere/zotero-better-bibtex/v6.0.0/test/fixtures/import/Author%20splitter%20failure.bib'
+  )
+  const expected = dedent`<div><span class="" id="citation--abu-zeid_1986--1">(Abu-Zeid et al., 1986)</span></div>`
+  assert.is(result, expected)
+})
+
 rehypeCitationTest('throw error if invalid url path', async () => {
   try {
     await processHtml(


### PR DESCRIPTION
We should not pass in `options.path` to `isValidHttpUrl` since the path refers to a local path and will throw an error is a URL is constructed from it.