### PR TITLE
Fix browser and node subpath exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,12 @@
       "node": "./dist/node/rehype-citation.mjs",
       "default": "./dist/browser/rehype-citation.mjs"
     },
-    "./browser/": {
-      "default": "./dist/browser/"
+    "./browser": {
+      "default": "./dist/browser/rehype-citation.mjs"
     },
-    "./node/": {
-      "default": "./dist/node/"
+    "./node": {
+      "types": "./dist/node/index.d.ts",
+      "default": "./dist/node/rehype-citation.mjs"
     }
   },
   "typesVersions": {
@@ -137,5 +138,8 @@
     "*.+(js|jsx|ts|tsx|json|css|md|mdx)": [
       "prettier --write"
     ]
+  },
+  "directories": {
+    "test": "test"
   }
 }


### PR DESCRIPTION
## Summary

Makes the browser and node subpath exports resolvable by using explicit `./browser` and `./node` export keys.

## Why

The published package defines trailing-slash export keys:

- `./browser/`
- `./node/`

In Node, those keys are not exposed as importable subpaths. `import.meta.resolve('rehype-citation/browser/')` and `import.meta.resolve('rehype-citation/node/')` fail with `ERR_PACKAGE_PATH_NOT_EXPORTED`.

This PR maps explicit subpath specifiers to the built entry files that are already present in the package:

- `./dist/browser/rehype-citation.mjs`
- `./dist/node/rehype-citation.mjs`

## Validation

- Reproduced the published package failure with `import.meta.resolve('rehype-citation/browser/')` and `import.meta.resolve('rehype-citation/node/')`
- Ran `npm install`
- Ran `npm run build`
- Ran `npm pack --dry-run --json --ignore-scripts`
- Ran a package metadata reference assertion against the built `dist` files
- Installed the patched tarball into a temp project and confirmed `import.meta.resolve('rehype-citation/browser')` and `import.meta.resolve('rehype-citation/node')` resolve successfully
- Ran `git diff --check`
