### PR TITLE
fix punycode deprecation warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "hast-util-from-parse5": "^8.0.3",
         "js-yaml": "^4.1.1",
         "parse5": "^8.0.0",
+        "punycode": "^2.3.1",
         "unified": "^11.0.5",
         "unist-util-visit": "^5.1.0"
       },
@@ -9722,7 +9723,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "bootstrap": "node bootstrap.js",
     "build": "npm run build:node && npm run build:browser",
     "build:browser": "microbundle index.js src/cite.js src/generator.js --output dist/browser --format modern --define isNode=false --alias ./html-transform-node.js=./html-transform-browser.js",
-    "build:node": "tsc -b && microbundle index.js src/cite.js src/generator.js --target node --output dist/node --format modern --define isNode=true",
+    "build:node": "tsc -b && microbundle index.js src/cite.js src/generator.js --target node --output dist/node --format modern --define isNode=true --alias punycode=punycode/punycode.js",
     "tsc": "tsc --watch",
     "lint": "eslint .",
     "prettier": "prettier --write '*.js'",
@@ -84,6 +84,7 @@
     "hast-util-from-parse5": "^8.0.3",
     "js-yaml": "^4.1.1",
     "parse5": "^8.0.0",
+    "punycode": "^2.3.1",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.1.0"
   },


### PR DESCRIPTION
Added userland replacement of punycode to dependencies and added alias to grap the right punycode (userland instead of the deprecated build-in punycode).

Fixes #64 